### PR TITLE
Throw error with correct code when node exists

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,16 @@ var __extends = (this && this.__extends) || function (d, b) {
     function __() { this.constructor = d; }
     d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
 };
+function SystemError(message, code) {
+  this.name = 'SystemError';
+  this.message = message || 'Default Message';
+  if (code) {
+    this.code = code;
+  }
+  this.stack = (new Error()).stack;
+}
+SystemError.prototype = Object.create(Error.prototype);
+SystemError.prototype.constructor = SystemError;
 /**
  * path.resolve
  * path.sep
@@ -167,7 +177,7 @@ var memfs;
         Volume.prototype.addDir = function (fullpath, layer) {
             fullpath = this.normalize(fullpath);
             if (this.flattened[fullpath])
-                throw Error('Node already exists: ' + fullpath);
+                throw SystemError('Node already exists: ' + fullpath, 'EEXIST');
             var relative = path.relative(layer.mountpoint, fullpath);
             relative = relative.replace(/\\/g, '/'); // Always use forward slashed in our virtual relative paths.
             var directory = new Directory(relative, layer);
@@ -178,7 +188,7 @@ var memfs;
         Volume.prototype.addFile = function (fullpath, layer) {
             fullpath = this.normalize(fullpath);
             if (this.flattened[fullpath])
-                throw Error('Node already exists: ' + fullpath);
+                throw SystemError('Node already exists: ' + fullpath, 'EEXIST');
             var relative = path.relative(layer.mountpoint, fullpath);
             relative = relative.replace(/\\/g, '/'); // Always use forward slashed in our virtual relative paths.
             var node = new File(relative, layer);


### PR DESCRIPTION
I've the following helper method to create directories:

```js
const mkdirSync = fs => (dirPath) => {
  try {
    fs.mkdirSync(dirPath);
  } catch (e) {
    if (e.code !== 'EEXIST') {
      throw e;
    }
  }
};
```

Unfortunately, this doesn't work with `memfs`, as `addDir`/`addFile` will throw a non-system error if a node exists (with no code defined).

This PR throws an error closer to what Node itself would actually throw: https://nodejs.org/api/errors.html#errors_system_errors

---

Lemme know if you need me to change anything about this PR to get it merged in. Really enjoyed working with `memfs`, particularly for testing. Thanks for your hard work!