### PR TITLE
updated fs-monkey and fixed win32 issue

### DIFF
--- a/lib/volume.js
+++ b/lib/volume.js
@@ -22,6 +22,7 @@ var setTimeoutUnref_1 = require("./setTimeoutUnref");
 var stream_1 = require("stream");
 var util = require('util');
 var isWin = process_1.default.platform === 'win32';
+var unixify = isWin ? require("fs-monkey/lib/correctPath").unixify : function (p) { return p; };
 // type TCallbackWrite = (err?: IError, bytesWritten?: number, source?: Buffer) => void;
 // type TCallbackWriteStr = (err?: IError, written?: number, str?: string) => void;
 // ---------------------------------------- Constants
@@ -258,10 +259,7 @@ function pathToFilename(path) {
 exports.pathToFilename = pathToFilename;
 function resolve(filename, base) {
     if (base === void 0) { base = process_1.default.cwd(); }
-    filename = path_1.resolve(base, filename);
-    if (isWin)
-        filename = require('unixify')(filename);
-    return filename;
+    return unixify(path_1.resolve(base, filename));
 }
 function filenameToSteps(filename, base) {
     var fullPath = resolve(filename, base);

--- a/package.json
+++ b/package.json
@@ -1,12 +1,23 @@
 {
   "name": "memfs",
-  "version": "2.5.0",
+  "version": "2.5.2",
   "description": "In-memory file-system with Node's fs API.",
   "main": "lib/index.js",
   "keywords": [
-    "fs", "filesystem", "fs.js", "memory-fs", "memfs",
-    "file", "file system", "mount", "memory", "in-memory",
-    "virtual", "test", "testing", "mock"
+    "fs",
+    "filesystem",
+    "fs.js",
+    "memory-fs",
+    "memfs",
+    "file",
+    "file system",
+    "mount",
+    "memory",
+    "in-memory",
+    "virtual",
+    "test",
+    "testing",
+    "mock"
   ],
   "repository": {
     "type": "git",
@@ -14,8 +25,7 @@
   },
   "dependencies": {
     "fast-extend": "0.0.2",
-    "fs-monkey": "^0.1.3",
-    "unixify": "^1.0.0"
+    "fs-monkey": "https://github.com/fearthecowboy/fs-monkey/releases/download/0.1.5/fs-monkey-0.1.5.tgz"
   },
   "devDependencies": {
     "mocha": "3.4.2",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "fast-extend": "0.0.2",
-    "fs-monkey": "https://github.com/fearthecowboy/fs-monkey/releases/download/0.1.5/fs-monkey-0.1.5.tgz"
+    "fs-monkey": "~0.1.5"
   },
   "devDependencies": {
     "mocha": "3.4.2",

--- a/src/volume.ts
+++ b/src/volume.ts
@@ -12,7 +12,7 @@ const util = require('util');
 
 
 const isWin = process.platform === 'win32';
-
+const unixify = isWin ? require("fs-monkey/lib/correctPath").unixify : p=>p;
 
 // ---------------------------------------- Types
 
@@ -373,9 +373,7 @@ export function pathToFilename(path: TFilePath): string {
 }
 
 function resolve(filename: string, base: string = process.cwd()): string {
-    filename = resolveCrossPlatform(base, filename);
-    if(isWin) filename = require('unixify')(filename);
-    return filename;
+    return unixify(resolveCrossPlatform(base, filename));
 }
 
 export function filenameToSteps(filename: string, base?: string): string[] {


### PR DESCRIPTION
**NOTE** This PR requires fs-monkey to have the [PR](https://github.com/streamich/fs-monkey/pull/2)  merged and published before this will work.

Using a memfs as for `node_modules` via fs-monkey was having a problem because unixify was inline-required (and gave problems during module resolution).

I inlined unixify in fs-monkey (as part of the [fix ](https://github.com/streamich/fs-monkey/pull/2) for win32 there and then pulled thru the implementation so that there was a few less dependencies (since fs-monkey was already a dep). 

