### PR TITLE
Make sure path is calculated correctly when renaming a file

### DIFF
--- a/lib/volume.js
+++ b/lib/volume.js
@@ -1182,7 +1182,7 @@ var Volume = (function () {
             oldLinkParent.deleteChild(link);
         }
         // Rename should overwrite the new path, if that exists.
-        link.steps = newPathSteps;
+        link.steps = newPathDirLink.steps.concat(newPathSteps);
         newPathDirLink.setChild(link.getName(), link);
     };
     Volume.prototype.renameSync = function (oldPath, newPath) {
@@ -1756,7 +1756,8 @@ function ReadStream(vol, path, options) {
         this.open();
     this.on('end', function () {
         if (this.autoClose) {
-            this.destroy();
+            if (this.destroy)
+                this.destroy();
         }
     });
 }

--- a/src/__tests__/volume.test.ts
+++ b/src/__tests__/volume.test.ts
@@ -790,6 +790,21 @@ describe('volume', () => {
         describe('.mkdirp(path[, mode], callback)', () => {
             xit('Create /dir1/dir2/dir3', () => {});
         });
+        describe('.renameSync(fromPath, toPath)', () => {
+          it ('Renames a file', () => {
+            const vol = Volume.fromJSON({
+              '/foo': 'bar'
+            });
+            expect(vol.root.getChild('foo').getNode().isFile()).toBe(true);
+            vol.renameSync('/foo', '/baz');
+            expect(vol.root.getChild('foo')).toBeUndefined();
+            expect(vol.root.getChild('baz').getNode().isFile()).toBe(true);
+            expect(vol.readFileSync('/baz', 'utf8')).toBe('bar');
+          })
+        });
+        describe('.rename(path, callback)', () => {
+          xit('...');
+        });
         describe('.rmdirSync(path)', () => {
             it('Remove single dir', () => {
                 const vol = new Volume;

--- a/src/volume.ts
+++ b/src/volume.ts
@@ -1400,7 +1400,7 @@ export class Volume {
         }
 
         // Rename should overwrite the new path, if that exists.
-        link.steps = newPathSteps;
+        link.steps = newPathDirLink.steps.concat(newPathSteps);
         newPathDirLink.setChild(link.getName(), link);
     }
 


### PR DESCRIPTION
When calling `rename`, I noticed that sometimes (especially when dealing with paths at the volume root), the new path was being calculated improperly.

This fixes that, and I also added a regression test for `rename`.