### PR TITLE
readFile should throw when reading a directory

### DIFF
--- a/src/__tests__/volume.test.ts
+++ b/src/__tests__/volume.test.ts
@@ -460,6 +460,12 @@ describe('volume', () => {
                     // TODO: Check the right error message.
                 }
             });
+            it('Attempt to read a directory should throw', () => {
+                const vol = new Volume;
+                vol.mkdirSync('/test');
+                const fn = () => vol.readFileSync('/test');
+                expect(fn).toThrowError('EISDIR');
+            });
         });
         describe('.readFile(path[, options], callback)', () => {
             const vol = new Volume;

--- a/src/volume.ts
+++ b/src/volume.ts
@@ -1015,6 +1015,12 @@ export class Volume {
         if(userOwnsFd) {
             fd = id as number;
         } else {
+            const steps = filenameToSteps(id as string);
+            const link: Link = this.getResolvedLink(steps);    
+            const node = link.getNode();
+            if(node.isDirectory())
+                throwError(EISDIR, 'open', link.getPath());
+
             fd = this.openSync(id as TFilePath, flagsNum);
         }
 


### PR DESCRIPTION
```
❯ node
> var fs = require('fs')
undefined
> fs.readFileSync('package.json')
<Buffer 7b 0a 20 20 22 6e 61 6d 65 22 3a 20 22 6d 72 6d 2d 63 6f 72 65 22 2c 0a 20 20 22 76 65 72 73 69 6f 6e 22 3a 20 22 30 2e 30 2e 30 2d 64 65 76 65 6c 6f ... >
> fs.readFileSync('node_modules')
Error: EISDIR: illegal operation on a directory, read
    at Object.fs.readSync (fs.js:675:18)
    at tryReadSync (fs.js:540:20)
    at Object.fs.readFileSync (fs.js:583:19)
>
```