### PR TITLE
fix: add setImmediate.bind

### DIFF
--- a/src/setImmediate.ts
+++ b/src/setImmediate.ts
@@ -3,8 +3,8 @@ type TSetImmediate = (callback: (...args) => void, args?) => void;
 let _setImmediate: TSetImmediate;
 
 /* istanbul ignore next */
-if(typeof setImmediate === 'function') _setImmediate = setImmediate;
+if(typeof setImmediate === 'function') _setImmediate = setImmediate.bind(global);
 /* istanbul ignore next */
-else _setImmediate = setTimeout;
+else _setImmediate = setTimeout.bind(global);
 
 export default _setImmediate as TSetImmediate;


### PR DESCRIPTION
Fixes the following issue when attempted in a browser under some
circumstances where `this !== global`:

```
Uncaught TypeError: Illegal invocation
    at Volume.wrapAsync (index-bundle.js:8692)
    at Volume.stat (index-bundle.js:9261)
```

Tested bundled using rollup in Chrome 69