### PR TITLE
feat: add relative option support for mkdir and mkdirSync

### DIFF
--- a/docs/api-status.md
+++ b/docs/api-status.md
@@ -52,8 +52,8 @@ implemented (you have access to any file), basically `fs.access()` is a no-op.
   - [x] `linkSync(existingPath, newPath)`
   - [x] `lstat(path, callback)`
   - [x] `lstatSync(path)`
-  - [x] `mkdir(path[, mode], callback)`
-  - [x] `mkdirSync(path[, mode])`
+  - [x] `mkdir(path[, options], callback)`
+  - [x] `mkdirSync(path[, options])`
   - [x] `mkdtemp(prefix[, options], callback)`
   - [x] `mkdtempSync(prefix[, options])`
   - [x] `open(path, flags[, mode], callback)`

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -100,6 +100,9 @@ vol.toJSON(); // {}
 
 #### `vol.mkdirp(path[, mode], callback)`
 
+> DEPRECATED: This method will be removed in next major release.
+> Use `vol.mkdir(..., {recursive: true}, callback)` instead.
+
 Legacy interface, which now uses the `recursive` option of `vol.mkdir`.
 
 Creates a directory tree recursively. `path` specifies a directory to
@@ -107,6 +110,9 @@ create and can be a string, `Buffer`, or an `URL` object. `callback` is
 called on completion and may receive only one argument - an `Error` object.
 
 #### `vol.mkdirpSync(path[, mode])`
+
+> DEPRECATED: This method will be removed in next major release.
+> Use `vol.mkdirSync(..., {recursive: true})` instead.
 
 Legacy interface, which now uses the `recursive` option of `vol.mkdirSync`.
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -98,13 +98,17 @@ vol.reset();
 vol.toJSON(); // {}
 ```
 
-#### `vol.mkdirp(path, callback)`
+#### `vol.mkdirp(path[, mode], callback)`
+
+Legacy interface, which now uses the `recursive` option of `vol.mkdir`.
 
 Creates a directory tree recursively. `path` specifies a directory to
 create and can be a string, `Buffer`, or an `URL` object. `callback` is
 called on completion and may receive only one argument - an `Error` object.
 
-#### `vol.mkdirpSync(path)`
+#### `vol.mkdirpSync(path[, mode])`
+
+Legacy interface, which now uses the `recursive` option of `vol.mkdirSync`.
 
 A synchronous version of `vol.mkdirp()`. This method throws.
 

--- a/src/__tests__/volume.test.ts
+++ b/src/__tests__/volume.test.ts
@@ -825,7 +825,7 @@ describe('volume', () => {
         describe('.utimes(path, atime, mtime, callback)', () => {
             xit('...', () => {});
         });
-        describe('.mkdirSync(path[, mode])', () => {
+        describe('.mkdirSync(path[, options])', () => {
             it('Create dir at root', () => {
                 const vol = new Volume;
                 vol.mkdirSync('/test');
@@ -845,25 +845,9 @@ describe('volume', () => {
                 expect(dir2.getNode().isDirectory()).toBe(true);
                 expect(dir2.getPath()).toBe('/dir1/dir2');
             });
-        });
-        describe('.mkdir(path[, mode], callback)', () => {
-            xit('...');
-        });
-        describe('.mkdtempSync(prefix[, options])', () => {
-            it('Create temp dir at root', () => {
+            it('Create /dir1/dir2/dir3 recursively', () => {
                 const vol = new Volume;
-                const name = vol.mkdtempSync('/tmp-');
-                vol.writeFileSync(name + '/file.txt', 'lol');
-                expect(vol.toJSON()).toEqual({[name + '/file.txt']: 'lol'});
-            });
-        });
-        describe('.mkdtemp(prefix[, options], callback)', () => {
-            xit('Create temp dir at root', () => {});
-        });
-        describe('.mkdirpSync(path[, mode])', () => {
-            it('Create /dir1/dir2/dir3', () => {
-                const vol = new Volume;
-                vol.mkdirpSync('/dir1/dir2/dir3');
+                vol.mkdirSync('/dir1/dir2/dir3', { recursive: true });
                 const dir1 = vol.root.getChild('dir1');
                 const dir2 = dir1.getChild('dir2');
                 const dir3 = dir2.getChild('dir3');
@@ -875,8 +859,20 @@ describe('volume', () => {
                 expect(dir3.getNode().isDirectory()).toBe(true);
             });
         });
-        describe('.mkdirp(path[, mode], callback)', () => {
-            xit('Create /dir1/dir2/dir3', () => {});
+        describe('.mkdir(path[, mode], callback)', () => {
+            xit('...');
+            xit('Create /dir1/dir2/dir3', () => { });
+        });
+        describe('.mkdtempSync(prefix[, options])', () => {
+            it('Create temp dir at root', () => {
+                const vol = new Volume;
+                const name = vol.mkdtempSync('/tmp-');
+                vol.writeFileSync(name + '/file.txt', 'lol');
+                expect(vol.toJSON()).toEqual({[name + '/file.txt']: 'lol'});
+            });
+        });
+        describe('.mkdtemp(prefix[, options], callback)', () => {
+            xit('Create temp dir at root', () => {});
         });
         describe('.rmdirSync(path)', () => {
             it('Remove single dir', () => {


### PR DESCRIPTION
Add support for `relative` option for `fs.mkdir` and `fs.mkdirSync` functions by using `vol.mkdirp` implementation. 

Make `vol.mkdirp` and `vol.mkdirpSync` functions deprecated.