### PR TITLE
feat: support readdir withfiletypes option

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -18,6 +18,7 @@ describe('memfs', () => {
     });
     it('Exports constructors', () => {
         expect(typeof memfs.Stats).toBe('function');
+        expect(typeof memfs.Dirent).toBe('function');
         expect(typeof memfs.ReadStream).toBe('function');
         expect(typeof memfs.WriteStream).toBe('function');
         expect(typeof memfs.FSWatcher).toBe('function');

--- a/src/__tests__/volume.test.ts
+++ b/src/__tests__/volume.test.ts
@@ -1,4 +1,4 @@
-import {Link, Node, Stats} from "../node";
+import {Link, Node, Stats, Dirent} from "../node";
 import {Volume, filenameToSteps, StatWatcher} from "../volume";
 
 
@@ -732,13 +732,27 @@ describe('volume', () => {
             xit('...');
         });
         describe('.readdirSync(path)', () => {
-            const vol = new Volume;
             it('Returns simple list', () => {
+                const vol = new Volume;
                 vol.writeFileSync('/1.js', '123');
                 vol.writeFileSync('/2.js', '123');
                 const list = vol.readdirSync('/');
                 expect(list.length).toBe(2);
                 expect(list).toEqual(['1.js', '2.js']);
+            });
+            it('Returns a Dirent list', () => {
+                const vol = new Volume;
+                vol.writeFileSync('/1', '123');
+                vol.mkdirSync('/2');
+                const list = vol.readdirSync('/', { withFileTypes: true });
+                expect(list.length).toBe(2);
+                expect(list[0]).toBeInstanceOf(Dirent);
+                const dirent0 = list[0] as Dirent;
+                expect(dirent0.name).toBe('1');
+                expect(dirent0.isFile()).toBe(true);
+                const dirent1 = list[1] as Dirent;
+                expect(dirent1.name).toBe('2');
+                expect(dirent1.isDirectory()).toBe(true);
             });
         });
         describe('.readdir(path, callback)', () => {

--- a/src/__tests__/volume.test.ts
+++ b/src/__tests__/volume.test.ts
@@ -639,7 +639,7 @@ describe('volume', () => {
         describe('.lstatSync(path)', () => {
             const vol = new Volume;
             const dojo = vol.root.createChild('dojo.js');
-            const data = '(funciton(){})();';
+            const data = '(function(){})();';
             dojo.getNode().setString(data);
 
             it('Returns basic file stats', () => {
@@ -663,7 +663,7 @@ describe('volume', () => {
         describe('.statSync(path)', () => {
             const vol = new Volume;
             const dojo = vol.root.createChild('dojo.js');
-            const data = '(funciton(){})();';
+            const data = '(function(){})();';
             dojo.getNode().setString(data);
             it('Returns basic file stats', () => {
                 const stats = vol.statSync('/dojo.js');
@@ -696,7 +696,7 @@ describe('volume', () => {
         describe('.fstatSync(fd)', () => {
             const vol = new Volume;
             const dojo = vol.root.createChild('dojo.js');
-            const data = '(funciton(){})();';
+            const data = '(function(){})();';
             dojo.getNode().setString(data);
 
             it('Returns basic file stats', () => {

--- a/src/encoding.ts
+++ b/src/encoding.ts
@@ -1,0 +1,18 @@
+import errors = require('./internal/errors');
+
+export type TDataOut = string | Buffer;             // Data formats we give back to users.
+export type TEncoding = 'ascii' | 'utf8' | 'utf16le' | 'ucs2' | 'base64' | 'latin1' | 'binary' | 'hex';
+export type TEncodingExtended = TEncoding | 'buffer';
+
+export const ENCODING_UTF8: TEncoding = 'utf8';
+
+export function assertEncoding(encoding: string) {
+    if(encoding && !Buffer.isEncoding(encoding))
+        throw new errors.TypeError('ERR_INVALID_OPT_VALUE_ENCODING', encoding);
+}
+
+export function strToEncoding(str: string, encoding?: TEncodingExtended): TDataOut {
+    if(!encoding || (encoding === ENCODING_UTF8)) return str;           // UTF-8
+    if(encoding === 'buffer') return new Buffer(str);                   // `buffer` encoding
+    return (new Buffer(str)).toString(encoding);                        // Custom encoding
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import {Stats} from './node';
+import {Stats, Dirent} from './node';
 import {Volume as _Volume, StatWatcher, FSWatcher, toUnixTimestamp, IReadStream, IWriteStream} from './volume';
 import * as volume from './volume';
 const {fsSyncMethods, fsAsyncMethods} = require('fs-monkey/lib/util/lists');
@@ -16,6 +16,7 @@ export const vol = new _Volume;
 export interface IFs extends _Volume {
     constants: typeof constants,
     Stats: new (...args) => Stats,
+    Dirent: new (...args) => Dirent,
     StatWatcher: new () => StatWatcher,
     FSWatcher: new () => FSWatcher,
     ReadStream: new (...args) => IReadStream,
@@ -24,7 +25,7 @@ export interface IFs extends _Volume {
 }
 
 export function createFsFromVolume(vol: _Volume): IFs {
-    const fs = {F_OK, R_OK, W_OK, X_OK, constants, Stats} as any as IFs;
+    const fs = {F_OK, R_OK, W_OK, X_OK, constants, Stats, Dirent} as any as IFs;
 
     // Bind FS methods.
     for(const method of fsSyncMethods)

--- a/src/node.ts
+++ b/src/node.ts
@@ -2,6 +2,8 @@ import process from './process';
 import {constants, S} from "./constants";
 import {Volume} from "./volume";
 import {EventEmitter} from "events";
+import {TEncodingExtended, strToEncoding, TDataOut} from './encoding';
+
 const {S_IFMT, S_IFDIR, S_IFREG, S_IFBLK, S_IFCHR, S_IFLNK, S_IFIFO, S_IFSOCK, O_APPEND} = constants;
 
 
@@ -507,6 +509,57 @@ export class Stats {
     dev: number = 0;
     mode: number = 0;
     nlink: number = 0;
+
+    private _checkModeProperty(property: number): boolean {
+        return (this.mode & S_IFMT) === property;
+    }
+
+    isDirectory(): boolean {
+        return this._checkModeProperty(S_IFDIR);
+    }
+
+    isFile(): boolean {
+        return this._checkModeProperty(S_IFREG);
+    }
+
+    isBlockDevice(): boolean {
+        return this._checkModeProperty(S_IFBLK);
+    }
+
+    isCharacterDevice(): boolean {
+        return this._checkModeProperty(S_IFCHR);
+    }
+
+    isSymbolicLink(): boolean {
+        return this._checkModeProperty(S_IFLNK);
+    }
+
+    isFIFO(): boolean {
+        return this._checkModeProperty(S_IFIFO);
+    }
+
+    isSocket(): boolean {
+        return this._checkModeProperty(S_IFSOCK);
+    }
+}
+
+/**
+ * A directory entry, like `fs.Dirent`.
+ */
+export class Dirent {
+
+    static build(link: Link, encoding: TEncodingExtended) {
+        const dirent = new Dirent;
+        const {mode} = link.getNode();
+
+        dirent.name = strToEncoding(link.getName(), encoding);
+        dirent.mode = mode;
+
+        return dirent;
+    }
+
+    name: TDataOut = '';
+    private mode: number = 0;
 
     private _checkModeProperty(property: number): boolean {
         return (this.mode & S_IFMT) === property;


### PR DESCRIPTION
Add `withFileTypes` option support for `fs.readdir` and `fs.readdirSync`. 

Add new `fs.Dirent` class (obviously) which is similar to `fs.Stats` but also need the `encoding` option for constructing the name.

Move all encoding related types and functions to new `encoding.ts` file.