### PR TITLE
feat: promises api

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,9 @@ This package depends on the following Node modules: `buffer`, `events`,
 It also uses `process` and `setImmediate` globals, but mocks them, if not
 available.
 
+It uses `Promise` when available and throws when `promises` property is
+accessed in an environment that do not support this ES2015 feature.
+
 [npm-url]: https://www.npmjs.com/package/memfs
 [npm-badge]: https://img.shields.io/npm/v/memfs.svg
 [travis-url]: https://travis-ci.org/streamich/memfs

--- a/docs/api-status.md
+++ b/docs/api-status.md
@@ -4,7 +4,7 @@ All of the [Node's `fs` API](https://nodejs.org/api/fs.html) is implemented.
 Some error messages may be inaccurate. File permissions are currently not
 implemented (you have access to any file), basically `fs.access()` is a no-op.
 
-  - [ ] Promises
+  - [x] Promises
   - [x] Constants
   - [x] `FSWatcher`
   - [x] `ReadStream`

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -35,4 +35,7 @@ describe('memfs', () => {
             expect(typeof memfs[method]).toBe('function');
         }
     });
+    it('Exports promises API', () => {
+        expect(typeof memfs.promises).toBe('object');
+    });
 });

--- a/src/__tests__/promises.test.ts
+++ b/src/__tests__/promises.test.ts
@@ -1,0 +1,629 @@
+import { Volume } from '../volume';
+
+describe('Promises API', () => {
+    describe('FileHandle', () => {
+        it('API should have a FileHandle property', () => {
+            const vol = new Volume;
+            const { promises } = vol;
+            expect(typeof promises.FileHandle).toBe('function');
+        });
+        describe('fd', () => {
+            it('FileHandle should have a fd property', async () => {
+                const vol = new Volume;
+                const { promises } = vol;
+                vol.fromJSON({
+                    '/foo': 'bar',
+                });
+                const fileHandle = await promises.open('/foo', 'r');
+                expect(typeof fileHandle.fd).toEqual('number');
+                await fileHandle.close();
+            });
+        });
+        describe('appendFile(data[, options])', () => {
+            const vol = new Volume;
+            const { promises } = vol;
+            vol.fromJSON({
+                '/foo': 'bar',
+            });
+            it('Append data to an existing file', async () => {
+                const fileHandle = await promises.open('/foo', 'a');
+                await fileHandle.appendFile('baz');
+                expect(vol.readFileSync('/foo').toString()).toEqual('barbaz');
+                await fileHandle.close();
+            });
+            it('Reject when the file handle was closed', async () => {
+                const fileHandle = await promises.open('/foo', 'a');
+                await fileHandle.close();
+                return expect(fileHandle.appendFile('/foo', 'baz')).rejects.toBeInstanceOf(Error);
+            });
+        });
+        describe('chmod(mode)', () => {
+            const vol = new Volume;
+            const { promises } = vol;
+            vol.fromJSON({
+                '/foo': 'bar',
+            });
+            it('Change mode of existing file', async () => {
+                const fileHandle = await promises.open('/foo', 'a');
+                await fileHandle.chmod(0o444);
+                expect(vol.statSync('/foo').mode & 0o777).toEqual(0o444);
+                await fileHandle.close();
+            });
+            it('Reject when the file handle was closed', async () => {
+                const fileHandle = await promises.open('/foo', 'a');
+                await fileHandle.close();
+                return expect(fileHandle.chmod(0o666)).rejects.toBeInstanceOf(Error);
+            });
+        });
+        describe('chown(uid, gid)', () => {
+            const vol = new Volume;
+            const { promises } = vol;
+            vol.fromJSON({
+                '/foo': 'bar',
+            });
+            const { uid, gid } = vol.statSync('/foo');
+            it('Change uid and gid of existing file', async () => {
+                const fileHandle = await promises.open('/foo', 'a');
+                await fileHandle.chown(uid + 1, gid + 1);
+                const stats = vol.statSync('/foo');
+                expect(stats.uid).toEqual(uid + 1);
+                expect(stats.gid).toEqual(gid + 1);
+                await fileHandle.close();
+            });
+            it('Reject when the file handle was closed', async () => {
+                const fileHandle = await promises.open('/foo', 'a');
+                await fileHandle.close();
+                return expect(fileHandle.chown(uid + 2, gid + 2)).rejects.toBeInstanceOf(Error);
+            });
+        });
+        // close(): covered by all other tests
+        describe('datasync()', () => {
+            const vol = new Volume;
+            const { promises } = vol;
+            vol.fromJSON({
+                '/foo': 'bar',
+            });
+            it('Synchronize data with an existing file', async () => {
+                const fileHandle = await promises.open('/foo', 'r+');
+                await fileHandle.datasync();
+                expect(vol.readFileSync('/foo').toString()).toEqual('bar');
+                await fileHandle.close();
+            });
+            it('Reject when the file handle was closed', async () => {
+                const fileHandle = await promises.open('/foo', 'r+');
+                await fileHandle.close();
+                return expect(fileHandle.datasync()).rejects.toBeInstanceOf(Error);
+            });
+        });
+        describe('read(buffer, offset, length, position)', () => {
+            const vol = new Volume;
+            const { promises } = vol;
+            vol.fromJSON({
+                '/foo': 'bar',
+            });
+            it('Read data from an existing file', async () => {
+                const fileHandle = await promises.open('/foo', 'r+');
+                const buff = Buffer.from('foo');
+                const { bytesRead, buffer } = await fileHandle.read(buff, 0, 42, 0);
+                expect(bytesRead).toEqual(3);
+                expect(buffer).toBe(buff);
+                await fileHandle.close();
+            });
+            it('Reject when the file handle was closed', async () => {
+                const fileHandle = await promises.open('/foo', 'r+');
+                await fileHandle.close();
+                return expect(fileHandle.read(Buffer.from('foo'), 0, 42, 0)).rejects.toBeInstanceOf(Error);
+            });
+        });
+        describe('readFile([options])', () => {
+            const vol = new Volume;
+            const { promises } = vol;
+            vol.fromJSON({
+                '/foo': 'bar',
+            });
+            it('Read data from an existing file', async () => {
+                const fileHandle = await promises.open('/foo', 'r+');
+                expect((await fileHandle.readFile()).toString()).toEqual('bar');
+                await fileHandle.close();
+            });
+            it('Reject when the file handle was closed', async () => {
+                const fileHandle = await promises.open('/foo', 'r+');
+                await fileHandle.close();
+                return expect(fileHandle.readFile()).rejects.toBeInstanceOf(Error);
+            });
+        });
+        describe('stat()', () => {
+            const vol = new Volume;
+            const { promises } = vol;
+            vol.fromJSON({
+                '/foo': 'bar',
+            });
+            it('Return stats of an existing file', async () => {
+                const fileHandle = await promises.open('/foo', 'r+');
+                expect((await fileHandle.stat()).isFile()).toEqual(true);
+                await fileHandle.close();
+            });
+            it('Reject when the file handle was closed', async () => {
+                const fileHandle = await promises.open('/foo', 'r+');
+                await fileHandle.close();
+                return expect(fileHandle.stat()).rejects.toBeInstanceOf(Error);
+            });
+        });
+        describe('truncate([len])', () => {
+            const vol = new Volume;
+            const { promises } = vol;
+            vol.fromJSON({
+                '/foo': '0123456789',
+            });
+            it('Truncate an existing file', async () => {
+                const fileHandle = await promises.open('/foo', 'r+');
+                await fileHandle.truncate(5);
+                expect(vol.readFileSync('/foo').toString()).toEqual('01234');
+                await fileHandle.close();
+            });
+            it('Reject when the file handle was closed', async () => {
+                const fileHandle = await promises.open('/foo', 'r+');
+                await fileHandle.close();
+                return expect(fileHandle.truncate(5)).rejects.toBeInstanceOf(Error);
+            });
+        });
+        describe('utimes(atime, mtime)', () => {
+            const vol = new Volume;
+            const { promises } = vol;
+            vol.fromJSON({
+                '/foo': '0123456789',
+            });
+            const fttDeparture = new Date(1985, 9, 26, 1, 21); // ftt stands for "first time travel" :-)
+            const fttArrival = new Date(fttDeparture.getTime() + 60000);
+            it('Changes times of an existing file', async () => {
+                const fileHandle = await promises.open('/foo', 'r+');
+                await fileHandle.utimes(fttArrival, fttDeparture);
+                const stats = vol.statSync('/foo');
+                expect(stats.atime).toEqual(new Date(fttArrival));
+                expect(stats.mtime).toEqual(new Date(fttDeparture));
+                await fileHandle.close();
+            });
+            it('Reject when the file handle was closed', async () => {
+                const fileHandle = await promises.open('/foo', 'r+');
+                await fileHandle.close();
+                return expect(fileHandle.utimes(fttArrival, fttDeparture)).rejects.toBeInstanceOf(Error);
+            });
+        });
+        describe('write(buffer[, offset[, length[, position]]])', () => {
+            const vol = new Volume;
+            const { promises } = vol;
+            vol.fromJSON({
+                '/foo': 'bar',
+            });
+            it('Write data to an existing file', async () => {
+                const fileHandle = await promises.open('/foo', 'w');
+                await fileHandle.write(Buffer.from('foo'));
+                expect(vol.readFileSync('/foo').toString()).toEqual('foo');
+                await fileHandle.close();
+            });
+            it('Reject when the file handle was closed', async () => {
+                const fileHandle = await promises.open('/foo', 'w');
+                await fileHandle.close();
+                return expect(fileHandle.write(Buffer.from('foo'))).rejects.toBeInstanceOf(Error);
+            });
+        });
+        describe('writeFile(data[, options])', () => {
+            const vol = new Volume;
+            const { promises } = vol;
+            vol.fromJSON({
+                '/foo': 'bar',
+            });
+            it('Write data to an existing file', async () => {
+                const fileHandle = await promises.open('/foo', 'w');
+                await fileHandle.writeFile('foo');
+                expect(vol.readFileSync('/foo').toString()).toEqual('foo');
+                await fileHandle.close();
+            });
+            it('Reject when the file handle was closed', async () => {
+                const fileHandle = await promises.open('/foo', 'w');
+                await fileHandle.close();
+                return expect(fileHandle.writeFile('foo')).rejects.toBeInstanceOf(Error);
+            });
+        });
+    });
+    describe('access(path[, mode])', () => {
+        const vol = new Volume;
+        const { promises } = vol;
+        vol.fromJSON({
+            '/foo': 'bar',
+        });
+        it('Resolve when file exists', () => {
+            return expect(promises.access('/foo')).resolves.toBeUndefined();
+        });
+        it('Reject when file does not exist', () => {
+            return expect(promises.access('/bar')).rejects.toBeInstanceOf(Error);
+        });
+    });
+    describe('appendFile(path, data[, options])', () => {
+        it('Append data to existing file', async () => {
+            const vol = new Volume;
+            const { promises } = vol;
+            vol.fromJSON({
+                '/foo': 'bar',
+            });
+            await promises.appendFile('/foo', 'baz');
+            expect(vol.readFileSync('/foo').toString()).toEqual('barbaz');
+        });
+        it('Append data to existing file using FileHandle', async () => {
+            const vol = new Volume;
+            const { promises } = vol;
+            vol.fromJSON({
+                '/foo': 'bar',
+            });
+            const fileHandle = await promises.open('/foo', 'a');
+            await promises.appendFile(fileHandle, 'baz');
+            await fileHandle.close();
+            expect(vol.readFileSync('/foo').toString()).toEqual('barbaz');
+        });
+        it('Reject when trying to write on a directory', () => {
+            const vol = new Volume;
+            const { promises } = vol;
+            vol.fromJSON({
+                '/foo': null,
+            });
+            return expect(promises.appendFile('/foo', 'bar')).rejects.toBeInstanceOf(Error);
+        });
+    });
+    describe('chmod(path, mode)', () => {
+        const vol = new Volume;
+        const { promises } = vol;
+        vol.fromJSON({
+            '/foo': 'bar',
+        });
+        it('Change mode of existing file', async () => {
+            await promises.chmod('/foo', 0o444);
+            expect(vol.statSync('/foo').mode & 0o777).toEqual(0o444);
+        });
+        it ('Reject when file does not exist', () => {
+            return expect(promises.chmod('/bar', 0o444)).rejects.toBeInstanceOf(Error);
+        });
+    });
+    describe('chown(path, uid, gid)', () => {
+        const vol = new Volume;
+        const { promises } = vol;
+        vol.fromJSON({
+            '/foo': 'bar',
+        });
+        it('Change uid and gid of existing file', async () => {
+            const { uid, gid } = vol.statSync('/foo');
+            await promises.chown('/foo', uid + 1, gid + 1);
+            const stats = vol.statSync('/foo');
+            expect(stats.uid).toEqual(uid + 1);
+            expect(stats.gid).toEqual(gid + 1);
+        });
+        it ('Reject when file does not exist', () => {
+            return expect(promises.chown('/bar', 0, 0)).rejects.toBeInstanceOf(Error);
+        });
+    });
+    describe('copyFile(src, dest[, flags])', () => {
+        const vol = new Volume;
+        const { promises } = vol;
+        vol.fromJSON({
+            '/foo': 'bar',
+        });
+        it('Copy existing file', async () => {
+            await promises.copyFile('/foo', '/bar');
+            expect(vol.readFileSync('/bar').toString()).toEqual('bar');
+        });
+        it('Reject when file does not exist', () => {
+            return expect(promises.copyFile('/baz', '/qux')).rejects.toBeInstanceOf(Error);
+        });
+    });
+    describe('lchmod(path, mode)', () => {
+        const vol = new Volume;
+        const { promises } = vol;
+        vol.fromJSON({
+            '/foo': 'bar',
+        });
+        vol.symlinkSync('/foo', '/bar');
+        it('Change mode of existing file', async () => {
+            await promises.lchmod('/bar', 0o444);
+            expect(vol.statSync('/foo').mode & 0o777).toEqual(0o666);
+            expect(vol.lstatSync('/bar').mode & 0o777).toEqual(0o444);
+        });
+        it ('Reject when file does not exist', () => {
+            return expect(promises.lchmod('/baz', 0o444)).rejects.toBeInstanceOf(Error);
+        });
+    });
+    describe('lchown(path, uid, gid)', () => {
+        const vol = new Volume;
+        const { promises } = vol;
+        vol.fromJSON({
+            '/foo': 'bar',
+        });
+        vol.symlinkSync('/foo', '/bar');
+        it('Change uid and gid of existing file', async () => {
+            const fooStatsBefore = vol.statSync('/foo');
+            const { uid, gid } = vol.statSync('/bar');
+            await promises.lchown('/bar', uid + 1, gid + 1);
+            const fooStatsAfter = vol.statSync('/foo');
+            expect(fooStatsAfter.uid).toEqual(fooStatsBefore.uid);
+            expect(fooStatsAfter.gid).toEqual(fooStatsBefore.gid);
+            const stats = vol.lstatSync('/bar');
+            expect(stats.uid).toEqual(uid + 1);
+            expect(stats.gid).toEqual(gid + 1);
+        });
+        it ('Reject when file does not exist', () => {
+            return expect(promises.lchown('/baz', 0, 0)).rejects.toBeInstanceOf(Error);
+        });
+    });
+    describe('link(existingPath, newPath)', () => {
+        const vol = new Volume;
+        const { promises } = vol;
+        vol.fromJSON({
+            '/foo': 'bar',
+        });
+        it('Create hard link on existing file', async () => {
+            await promises.link('/foo', '/bar');
+            expect(vol.existsSync('/bar')).toEqual(true);
+        });
+        it('Reject when file does not exist', () => {
+            return expect(promises.link('/baz', '/qux')).rejects.toBeInstanceOf(Error);
+        });
+    });
+    describe('lstat(path)', () => {
+        const vol = new Volume;
+        const { promises } = vol;
+        vol.fromJSON({
+            '/foo': 'bar',
+        });
+        vol.symlinkSync('/foo', '/bar');
+        it('Get stats on an existing symbolic link', async () => {
+            const stats = await promises.lstat('/bar');
+            expect(stats.isSymbolicLink()).toEqual(true);
+        });
+        it('Reject when symbolic link does not exist', () => {
+            return expect(promises.lstat('/baz')).rejects.toBeInstanceOf(Error);
+        });
+    });
+    describe('mkdir(path[, options])', () => {
+        const vol = new Volume;
+        const { promises } = vol;
+        it('Creates a directory', async () => {
+            await promises.mkdir('/foo');
+            expect(vol.statSync('/foo').isDirectory()).toEqual(true);
+        });
+        it('Reject when a file already exists', () => {
+            vol.writeFileSync('/bar', 'bar');
+            return expect(promises.mkdir('/bar')).rejects.toBeInstanceOf(Error);
+        });
+    });
+    describe('mkdtemp(prefix[, options])', () => {
+        const vol = new Volume;
+        const { promises } = vol;
+        it('Creates a temporary directory', async () => {
+            const tmp = await promises.mkdtemp('/foo');
+            expect(vol.statSync(tmp).isDirectory()).toEqual(true);
+        });
+        it('Reject when parent directory does not exist', () => {
+            return expect(promises.mkdtemp('/foo/bar')).rejects.toBeInstanceOf(Error);
+        });
+    });
+    describe('open(path, flags[, mode])', () => {
+        const vol = new Volume;
+        const { promises } = vol;
+        vol.fromJSON({
+            '/foo': 'bar',
+        });
+        it('Open an existing file', async () => {
+            expect(await promises.open('/foo', 'r')).toBeInstanceOf(promises.FileHandle);
+        });
+        it('Reject when file does not exist', () => {
+            return expect(promises.open('/bar', 'r')).rejects.toBeInstanceOf(Error);
+        });
+    });
+    describe('readdir(path[, options])', () => {
+        const vol = new Volume;
+        const { promises } = vol;
+        vol.fromJSON({
+            '/foo': null,
+            '/foo/bar': 'bar',
+            '/foo/baz': 'baz',
+        });
+        it('Read an existing directory', async () => {
+            expect(await promises.readdir('/foo')).toEqual([ 'bar', 'baz' ]);
+        });
+        it('Reject when directory does not exist', () => {
+            return expect(promises.readdir('/bar')).rejects.toBeInstanceOf(Error);
+        });
+    });
+    describe('readFile(id[, options])', () => {
+        it('Read existing file', async () => {
+            const vol = new Volume;
+            const { promises } = vol;
+            vol.fromJSON({
+                '/foo': 'bar',
+            });
+            expect((await promises.readFile('/foo')).toString()).toEqual('bar');
+        });
+        it('Read existing file using FileHandle', async () => {
+            const vol = new Volume;
+            const { promises } = vol;
+            vol.fromJSON({
+                '/foo': 'bar',
+            });
+            const fileHandle = await promises.open('/foo', 'r');
+            expect((await promises.readFile(fileHandle)).toString()).toEqual('bar');
+            await fileHandle.close();
+        });
+        it('Reject when file does not exist', () => {
+            const vol = new Volume;
+            const { promises } = vol;
+            return expect(promises.readFile('/foo')).rejects.toBeInstanceOf(Error);
+        });
+    });
+    describe('readlink(path[, options])', () => {
+        const vol = new Volume;
+        const { promises } = vol;
+        vol.symlinkSync('/foo', '/bar');
+        it('Read an existing symbolic link', async () => {
+            expect((await promises.readlink('/bar')).toString()).toEqual('/foo');
+        });
+        it('Reject when symbolic link does not exist', () => {
+            return expect(promises.readlink('/foo')).rejects.toBeInstanceOf(Error);
+        });
+    });
+    describe('realpath(path[, options])', () => {
+        const vol = new Volume;
+        const { promises } = vol;
+        vol.fromJSON({
+            '/foo': null,
+            '/foo/bar': null,
+            '/foo/baz': 'baz',
+        });
+        vol.symlinkSync('/foo/baz', '/foo/qux');
+        it('Return real path of existing file', async () => {
+            console.log((await promises.realpath('/foo/bar/../qux')).toString());
+            expect((await promises.realpath('/foo/bar/../qux')).toString()).toEqual('/foo/baz');
+        });
+        it('Reject when file does not exist', () => {
+            return expect(promises.realpath('/bar')).rejects.toBeInstanceOf(Error);
+        });
+    });
+    describe('rename(oldPath, newPath)', () => {
+        it('Rename existing file', async () => {
+            const vol = new Volume;
+            const { promises } = vol;
+            vol.fromJSON({
+                '/foo': 'bar',
+            });
+                await promises.rename('/foo', '/bar');
+            expect(vol.readFileSync('/bar').toString()).toEqual('bar');
+        });
+        it('Reject when file does not exist', () => {
+            const vol = new Volume;
+            const { promises } = vol;
+            vol.fromJSON({
+                '/foo': 'bar',
+            });
+            return expect(promises.rename('/bar', '/baz')).rejects.toBeInstanceOf(Error);
+        });
+    });
+    describe('rmdir(path)', () => {
+        const vol = new Volume;
+        const { promises } = vol;
+        vol.fromJSON({
+            '/foo': null,
+        });
+        it('Remove an existing directory', async () => {
+            await promises.rmdir('/foo');
+            expect(vol.existsSync('/foo')).toEqual(false);
+        });
+        it('Reject when directory does not exist', () => {
+            return expect(promises.rmdir('/bar')).rejects.toBeInstanceOf(Error);
+        });
+    });
+    describe('stat(path)', () => {
+        const vol = new Volume;
+        const { promises } = vol;
+        vol.fromJSON({
+            '/foo': null,
+        });
+        it('Return stats of an existing directory', async () => {
+            expect((await promises.stat('/foo')).isDirectory()).toEqual(true);
+        });
+        it('Reject when directory does not exist', () => {
+            return expect(promises.stat('/bar')).rejects.toBeInstanceOf(Error);
+        });
+    });
+    describe('symlink(target, path[, type])', () => {
+        it('Create symbolic link', async () => {
+            const vol = new Volume;
+            const { promises } = vol;
+            vol.fromJSON({
+                '/foo': 'bar',
+            });
+            await promises.symlink('/foo', '/bar');
+            expect(vol.lstatSync('/bar').isSymbolicLink()).toEqual(true);
+        });
+        it('Reject when file already exists', () => {
+            const vol = new Volume;
+            const { promises } = vol;
+            vol.fromJSON({
+                '/foo': 'bar',
+            });
+            return expect(promises.symlink('/bar', '/foo')).rejects.toBeInstanceOf(Error);
+        });
+    });
+    describe('truncate(path[, len])', () => {
+        const vol = new Volume;
+        const { promises } = vol;
+        vol.fromJSON({
+            '/foo': '0123456789',
+        });
+        it('Truncate an existing file', async () => {
+            await promises.truncate('/foo', 5);
+            expect(vol.readFileSync('/foo').toString()).toEqual('01234');
+        });
+        it('Reject when file does not exist', () => {
+            return expect(promises.truncate('/bar')).rejects.toBeInstanceOf(Error);
+        });
+    });
+    describe('unlink(path)', () => {
+        const vol = new Volume;
+        const { promises } = vol;
+        vol.fromJSON({
+            '/foo': 'bar',
+        });
+        it('Unlink an existing file', async () => {
+            await promises.unlink('/foo');
+            expect(vol.existsSync('/foo')).toEqual(false);
+        });
+        it('Reject when file does not exist', () => {
+            return expect(promises.unlink('/bar')).rejects.toBeInstanceOf(Error);
+        });
+    });
+    describe('utimes(path, atime, mtime)', () => {
+        const vol = new Volume;
+        const { promises } = vol;
+        vol.fromJSON({
+            '/foo': 'bar',
+        });
+        const fttDeparture = new Date(1985, 9, 26, 1, 21);
+        const fttArrival = new Date(fttDeparture.getTime() + 60000);
+        it('Changes times of an existing file', async () => {
+            await promises.utimes('/foo', fttArrival, fttDeparture);
+            const stats = vol.statSync('/foo');
+            expect(stats.atime).toEqual(new Date(fttArrival));
+            expect(stats.mtime).toEqual(new Date(fttDeparture));
+        });
+        it('Reject when file does not exist', () => {
+            return expect(promises.utimes('/bar', fttArrival, fttDeparture)).rejects.toBeInstanceOf(Error);
+        });
+    });
+    describe('writeFile(id, data[, options])', () => {
+        it('Write data to an existing file', async () => {
+            const vol = new Volume;
+            const { promises } = vol;
+            vol.fromJSON({
+                '/foo': '',
+            });
+            await promises.writeFile('/foo', 'bar');
+            expect(vol.readFileSync('/foo').toString()).toEqual('bar');
+        });
+        it('Write data to existing file using FileHandle', async () => {
+            const vol = new Volume;
+            const { promises } = vol;
+            vol.fromJSON({
+                '/foo': '',
+            });
+            const fileHandle = await promises.open('/foo', 'w');
+            await promises.writeFile(fileHandle, 'bar');
+            expect(vol.readFileSync('/foo').toString()).toEqual('bar');
+            await fileHandle.close();
+        });
+        it('Reject when trying to write on a directory', () => {
+            const vol = new Volume;
+            const { promises } = vol;
+            vol.fromJSON({
+                '/foo': null,
+            });
+            return expect(promises.writeFile('/foo', 'bar')).rejects.toBeInstanceOf(Error);
+        });
+    });
+});

--- a/src/__tests__/volume.test.ts
+++ b/src/__tests__/volume.test.ts
@@ -419,7 +419,7 @@ describe('volume', () => {
             });
         });
         describe('.read(fd, buffer, offset, length, position, callback)', () => {
-            xit('...');
+            xit('...', () => {});
         });
         describe('.readFileSync(path[, options])', () => {
             const vol = new Volume;
@@ -595,7 +595,7 @@ describe('volume', () => {
             });
         });
         describe('.symlink(target, path[, type], callback)', () => {
-            xit('...');
+            xit('...', () => {});
         });
         describe('.realpathSync(path[, options])', () => {
             const vol = new Volume;
@@ -662,7 +662,7 @@ describe('volume', () => {
             });
         });
         describe('.lstat(path, callback)', () => {
-            xit('...');
+            xit('...', () => {});
         });
         describe('.statSync(path)', () => {
             const vol = new Volume;
@@ -695,7 +695,7 @@ describe('volume', () => {
             });
         });
         describe('.stat(path, callback)', () => {
-            xit('...');
+            xit('...', () => {});
         });
         describe('.fstatSync(fd)', () => {
             const vol = new Volume;
@@ -713,7 +713,7 @@ describe('volume', () => {
             });
         });
         describe('.fstat(fd, callback)', () => {
-            xit('...');
+            xit('...', () => {});
         });
         describe('.linkSync(existingPath, newPath)', () => {
             const vol = new Volume;
@@ -733,7 +733,7 @@ describe('volume', () => {
             });
         });
         describe('.link(existingPath, newPath, callback)', () => {
-            xit('...');
+            xit('...', () => {});
         });
         describe('.readdirSync(path)', () => {
             it('Returns simple list', () => {
@@ -760,7 +760,7 @@ describe('volume', () => {
             });
         });
         describe('.readdir(path, callback)', () => {
-            xit('...');
+            xit('...', () => {});
         });
         describe('.readlinkSync(path[, options])', () => {
             it('Simple symbolic link to one file', () => {
@@ -808,7 +808,7 @@ describe('volume', () => {
             });
         });
         describe('.ftruncate(fd[, len], callback)', () => {
-            xit('...');
+            xit('...', () => {});
         });
         describe('.truncateSync(path[, len])', () => {
             const vol = new Volume;
@@ -828,7 +828,7 @@ describe('volume', () => {
             });
         });
         describe('.truncate(path[, len], callback)', () => {
-            xit('...');
+            xit('...', () => {});
         });
         describe('.utimesSync(path, atime, mtime)', () => {
             const vol = new Volume;
@@ -878,7 +878,7 @@ describe('volume', () => {
             });
         });
         describe('.mkdir(path[, mode], callback)', () => {
-            xit('...');
+            xit('...', () => {});
             xit('Create /dir1/dir2/dir3', () => { });
         });
         describe('.mkdtempSync(prefix[, options])', () => {

--- a/src/__tests__/volume.test.ts
+++ b/src/__tests__/volume.test.ts
@@ -936,6 +936,12 @@ describe('volume', () => {
                 }, 1);
             });
         });
+        describe('.promises', () => {
+            it('Have a promises property', () => {
+                const vol = new Volume;
+                expect(typeof vol.promises).toBe('object');
+            });
+        });
     });
     describe('StatWatcher', () => {
         it('.vol points to current volume', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import {Stats, Dirent} from './node';
 import {Volume as _Volume, StatWatcher, FSWatcher, toUnixTimestamp, IReadStream, IWriteStream} from './volume';
 import * as volume from './volume';
+import { IPromisesAPI } from './promises';
 const {fsSyncMethods, fsAsyncMethods} = require('fs-monkey/lib/util/lists');
 import {constants} from './constants';
 const {F_OK, R_OK, W_OK, X_OK} = constants;
@@ -21,6 +22,7 @@ export interface IFs extends _Volume {
     FSWatcher: new () => FSWatcher,
     ReadStream: new (...args) => IReadStream,
     WriteStream: new (...args) => IWriteStream,
+    promises: IPromisesAPI,
     _toUnixTimestamp,
 }
 
@@ -39,6 +41,7 @@ export function createFsFromVolume(vol: _Volume): IFs {
     fs.FSWatcher = vol.FSWatcher;
     fs.WriteStream = vol.WriteStream;
     fs.ReadStream = vol.ReadStream;
+    fs.promises = vol.promises;
 
     fs._toUnixTimestamp = toUnixTimestamp;
 

--- a/src/node.ts
+++ b/src/node.ts
@@ -154,7 +154,7 @@ export class Node extends EventEmitter {
 
     chmod(perm: number) {
         this.perm = perm;
-        this.mode |= perm;
+        this.mode = (this.mode & ~0o777) | perm;
         this.touch();
     }
 

--- a/src/promises.ts
+++ b/src/promises.ts
@@ -1,0 +1,296 @@
+import {
+    Volume,
+    TFilePath,
+    TData,
+    TMode,
+    TFlags,
+    TFlagsCopy,
+    TSymlinkType,
+    TTime,
+    IOptions,
+    IAppendFileOptions,
+    IMkdirOptions,
+    IReaddirOptions,
+    IReadFileOptions,
+    IRealpathOptions,
+    IWriteFileOptions,
+} from './volume';
+import { Stats, Dirent } from './node';
+import { TDataOut } from './encoding';
+
+function promisify(
+    vol: Volume,
+    fn: string,
+    getResult: (result: any) => any = input => input,
+): (...args) => Promise<any> {
+    return (...args) => new Promise((resolve, reject) => {
+        vol[fn].bind(vol)(...args, (error, result) => {
+            if (error) return reject(error);
+            return resolve(getResult(result));
+        });
+    });
+}
+
+export type TFileHandleReadResult = {
+    bytesRead: number,
+    buffer: Buffer | Uint8Array,
+};
+
+export type TFileHandleWriteResult = {
+    bytesWritten: number,
+    buffer: Buffer | Uint8Array,
+};
+
+export interface IFileHandle {
+    fd: number;
+    appendFile(data: TData, options?: IAppendFileOptions | string): Promise<void>,
+    chmod(mode: TMode): Promise<void>,
+    chown(uid: number, gid: number): Promise<void>,
+    close(): Promise<void>,
+    datasync(): Promise<void>,
+    read(
+        buffer: Buffer | Uint8Array,
+        offset: number,
+        length: number,
+        position: number,
+    ): Promise<TFileHandleReadResult>,
+    readFile(options?: IReadFileOptions|string): Promise<TDataOut>,
+    stat(): Promise<Stats>,
+    truncate(len?: number): Promise<void>,
+    utimes(atime: TTime, mtime: TTime): Promise<void>,
+    write(
+        buffer: Buffer | Uint8Array,
+        offset?: number,
+        length?: number,
+        position?: number,
+    ): Promise<TFileHandleWriteResult>,
+    writeFile(data: TData, options?: IWriteFileOptions): Promise<void>,
+}
+
+export type TFileHandle = TFilePath | IFileHandle;
+
+export interface IPromisesAPI {
+    FileHandle,
+    access(path: TFilePath, mode?: number): Promise<void>,
+    appendFile(path: TFileHandle, data: TData, options?: IAppendFileOptions | string): Promise<void>,
+    chmod(path: TFilePath, mode: TMode): Promise<void>,
+    chown(path: TFilePath, uid: number, gid: number): Promise<void>,
+    copyFile(src: TFilePath, dest: TFilePath, flags?: TFlagsCopy): Promise<void>,
+    lchmod(path: TFilePath, mode: TMode): Promise<void>,
+    lchown(path: TFilePath, uid: number, gid: number): Promise<void>,
+    link(existingPath: TFilePath, newPath: TFilePath): Promise<void>,
+    lstat(path: TFilePath): Promise<Stats>,
+    mkdir(path: TFilePath, options?: TMode | IMkdirOptions): Promise<void>,
+    mkdtemp(prefix: string, options?: IOptions): Promise<TDataOut>,
+    open(path: TFilePath, flags: TFlags, mode?: TMode): Promise<FileHandle>,
+    readdir(path: TFilePath, options?: IReaddirOptions | string): Promise<TDataOut[]|Dirent[]>,
+    readFile(id: TFileHandle, options?: IReadFileOptions|string): Promise<TDataOut>,
+    readlink(path: TFilePath, options?: IOptions): Promise<TDataOut>,
+    realpath(path: TFilePath, options?: IRealpathOptions | string): Promise<TDataOut>,
+    rename(oldPath: TFilePath, newPath: TFilePath): Promise<void>,
+    rmdir(path: TFilePath): Promise<void>,
+    stat(path: TFilePath): Promise<Stats>,
+    symlink(target: TFilePath, path: TFilePath, type?: TSymlinkType): Promise<void>,
+    truncate(path: TFilePath, len?: number): Promise<void>,
+    unlink(path: TFilePath): Promise<void>,
+    utimes(path: TFilePath, atime: TTime, mtime: TTime): Promise<void>,
+    writeFile(id: TFileHandle, data: TData, options?: IWriteFileOptions): Promise<void>,
+}
+
+export class FileHandle implements IFileHandle {
+    private vol: Volume;
+
+    fd: number;
+
+    constructor(vol: Volume, fd: number) {
+        this.vol = vol;
+        this.fd = fd;
+    }
+
+    appendFile(data: TData, options?: IAppendFileOptions | string): Promise<void> {
+        return promisify(this.vol, 'appendFile')(this.fd, data, options);
+    }
+
+    chmod(mode: TMode): Promise<void> {
+        return promisify(this.vol, 'fchmod')(this.fd, mode);
+    }
+
+    chown(uid: number, gid: number): Promise<void> {
+        return promisify(this.vol, 'fchown')(this.fd, uid, gid);
+    }
+
+    close(): Promise<void> {
+        return promisify(this.vol, 'close')(this.fd);
+    }
+
+    datasync(): Promise<void> {
+        return promisify(this.vol, 'fdatasync')(this.fd);
+    }
+
+    read(
+        buffer: Buffer | Uint8Array,
+        offset: number,
+        length: number,
+        position: number,
+    ): Promise<TFileHandleReadResult> {
+        return promisify(this.vol, 'read', bytesRead => ({ bytesRead, buffer }))(
+            this.fd,
+            buffer,
+            offset,
+            length,
+            position
+        );
+    }
+
+    readFile(options?: IReadFileOptions|string): Promise<TDataOut> {
+        return promisify(this.vol, 'readFile')(this.fd, options);
+    }
+
+    stat(): Promise<Stats> {
+        return promisify(this.vol, 'fstat')(this.fd);
+    }
+
+    sync(): Promise<void> {
+        return promisify(this.vol, 'fsync')(this.fd);
+    }
+
+    truncate(len?: number): Promise<void> {
+        return promisify(this.vol, 'ftruncate')(this.fd, len);
+    }
+
+    utimes(atime: TTime, mtime: TTime): Promise<void> {
+        return promisify(this.vol, 'futimes')(this.fd, atime, mtime);
+    }
+
+    write(
+        buffer: Buffer | Uint8Array,
+        offset?: number,
+        length?: number,
+        position?: number,
+    ): Promise<TFileHandleWriteResult> {
+        return promisify(this.vol, 'write', bytesWritten => ({ bytesWritten, buffer }))(
+            this.fd,
+            buffer,
+            offset,
+            length,
+            position,
+        );
+    }
+
+    writeFile(data: TData, options?: IWriteFileOptions): Promise<void> {
+        return promisify(this.vol, 'writeFile')(this.fd, data, options);
+    }
+}
+
+export default function createPromisesApi(vol: Volume): IPromisesAPI {
+    return {
+        FileHandle,
+
+        access(path: TFilePath, mode?: number): Promise<void> {
+            return promisify(vol, 'access')(path, mode);
+        },
+
+        appendFile(path: TFileHandle, data: TData, options?: IAppendFileOptions | string): Promise<void> {
+            return promisify(vol, 'appendFile')(
+                path instanceof FileHandle ? path.fd : path as TFilePath,
+                data,
+                options,
+            );
+        },
+
+        chmod(path: TFilePath, mode: TMode): Promise<void> {
+            return promisify(vol, 'chmod')(path, mode);
+        },
+
+        chown(path: TFilePath, uid: number, gid: number): Promise<void> {
+            return promisify(vol, 'chown')(path, uid, gid);
+        },
+
+        copyFile(src: TFilePath, dest: TFilePath, flags?: TFlagsCopy): Promise<void> {
+            return promisify(vol, 'copyFile')(src, dest, flags);
+        },
+
+        lchmod(path: TFilePath, mode: TMode): Promise<void> {
+            return promisify(vol, 'lchmod')(path, mode);
+        },
+
+        lchown(path: TFilePath, uid: number, gid: number): Promise<void> {
+            return promisify(vol, 'lchown')(path, uid, gid);
+        },
+
+        link(existingPath: TFilePath, newPath: TFilePath): Promise<void> {
+            return promisify(vol, 'link')(existingPath, newPath);
+        },
+
+        lstat(path: TFilePath): Promise<Stats> {
+            return promisify(vol, 'lstat')(path);
+        },
+
+        mkdir(path: TFilePath, options?: TMode | IMkdirOptions): Promise<void> {
+            return promisify(vol, 'mkdir')(path, options);
+        },
+
+        mkdtemp(prefix: string, options?: IOptions): Promise<TDataOut> {
+            return promisify(vol, 'mkdtemp')(prefix, options);
+        },
+
+        open(path: TFilePath, flags: TFlags, mode?: TMode): Promise<FileHandle> {
+            return promisify(vol, 'open', fd => new FileHandle(vol, fd))(path, flags, mode);
+        },
+
+        readdir(path: TFilePath, options?: IReaddirOptions | string): Promise<TDataOut[]|Dirent[]> {
+            return promisify(vol, 'readdir')(path, options);
+        },
+
+        readFile(id: TFileHandle, options?: IReadFileOptions|string): Promise<TDataOut> {
+            return promisify(vol, 'readFile')(
+                id instanceof FileHandle ? id.fd : id as TFilePath,
+                options,
+            );
+        },
+
+        readlink(path: TFilePath, options?: IOptions): Promise<TDataOut> {
+            return promisify(vol, 'readlink')(path, options);
+        },
+
+        realpath(path: TFilePath, options?: IRealpathOptions | string): Promise<TDataOut> {
+            return promisify(vol, 'realpath')(path, options);
+        },
+
+        rename(oldPath: TFilePath, newPath: TFilePath): Promise<void> {
+            return promisify(vol, 'rename')(oldPath, newPath);
+        },
+
+        rmdir(path: TFilePath): Promise<void> {
+            return promisify(vol, 'rmdir')(path);
+        },
+
+        stat(path: TFilePath): Promise<Stats> {
+            return promisify(vol, 'stat')(path);
+        },
+
+        symlink(target: TFilePath, path: TFilePath, type?: TSymlinkType): Promise<void> {
+            return promisify(vol, 'symlink')(target, path, type);
+        },
+
+        truncate(path: TFilePath, len?: number): Promise<void> {
+            return promisify(vol, 'truncate')(path, len);
+        },
+
+        unlink(path: TFilePath): Promise<void> {
+            return promisify(vol, 'unlink')(path);
+        },
+
+        utimes(path: TFilePath, atime: TTime, mtime: TTime): Promise<void> {
+            return promisify(vol, 'utimes')(path, atime, mtime);
+        },
+
+        writeFile(id: TFileHandle, data: TData, options?: IWriteFileOptions): Promise<void> {
+            return promisify(vol, 'writeFile')(
+                id instanceof FileHandle ? id.fd : id as TFilePath,
+                data,
+                options,
+            );
+        },
+    };
+}

--- a/src/promises.ts
+++ b/src/promises.ts
@@ -182,7 +182,8 @@ export class FileHandle implements IFileHandle {
     }
 }
 
-export default function createPromisesApi(vol: Volume): IPromisesAPI {
+export default function createPromisesApi(vol: Volume): null | IPromisesAPI {
+    if (typeof Promise === 'undefined') return null;
     return {
         FileHandle,
 

--- a/src/volume.ts
+++ b/src/volume.ts
@@ -575,6 +575,7 @@ export class Volume {
                 'ExperimentalWarning',
             );
         }
+        if (this.promisesApi === null) throw new Error('Promise is not supported in this environment.');
         return this.promisesApi;
     }
 

--- a/src/volume.ts
+++ b/src/volume.ts
@@ -502,6 +502,8 @@ function validateGid(gid: number) {
 
 // ---------------------------------------- Volume
 
+let promisesWarn = true;
+
 /**
  * `Volume` represents a file system.
  */
@@ -566,6 +568,13 @@ export class Volume {
     private promisesApi = createPromisesApi(this);
 
     get promises() {
+        if (promisesWarn) {
+            promisesWarn = false;
+            require('process').emitWarning(
+                'The fs.promises API is experimental',
+                'ExperimentalWarning',
+            );
+        }
         return this.promisesApi;
     }
 

--- a/src/volume.ts
+++ b/src/volume.ts
@@ -904,10 +904,10 @@ export class Volume {
 
     private openFile(filename: string, flagsNum: number, modeNum: number, resolveSymlinks: boolean = true): File {
         const steps = filenameToSteps(filename);
-        let link: Link = this.getResolvedLink(steps);
+        let link: Link = resolveSymlinks ? this.getResolvedLink(steps) : this.getLink(steps);
 
         // Try creating a new file, if it does not exist.
-        if(!link) {
+        if(!link && (flagsNum & O_CREAT)) {
             // const dirLink: Link = this.getLinkParent(steps);
             const dirLink: Link = this.getResolvedLink(steps.slice(0, steps.length - 1));
             // if(!dirLink) throwError(ENOENT, 'open', filename);
@@ -919,6 +919,7 @@ export class Volume {
         }
 
         if(link) return this.openLink(link, flagsNum, resolveSymlinks);
+        throwError(ENOENT, 'open', filename);
     }
 
     private openBase(filename: string, flagsNum: number, modeNum: number, resolveSymlinks: boolean = true): number {

--- a/src/volume.ts
+++ b/src/volume.ts
@@ -485,7 +485,7 @@ export function toUnixTimestamp(time) {
  */
 function getArgAndCb<TArg, TRes>(arg: TArg | TCallback<TRes>, callback?: TCallback<TRes>, def?: TArg): [TArg, TCallback<TRes>] {
     return typeof arg === 'function'
-        ? [def, arg]
+        ? [def, arg as TCallback<TRes>]
         : [arg, callback];
 }
 

--- a/src/volume.ts
+++ b/src/volume.ts
@@ -465,14 +465,14 @@ export function toUnixTimestamp(time) {
     if(typeof time === 'string' && (+time == (time as any))) {
         return +time;
     }
+    if(time instanceof Date) {
+        return time.getTime() / 1000;
+    }
     if(isFinite(time)) {
         if (time < 0) {
             return Date.now() / 1000;
         }
         return time;
-    }
-    if(time instanceof Date) {
-        return time.getTime() / 1000;
     }
     throw new Error('Cannot parse time: ' + time);
 }

--- a/src/volume.ts
+++ b/src/volume.ts
@@ -1389,7 +1389,7 @@ export class Volume {
         return strToEncoding(realLink.getPath(), encoding);
     }
 
-    realpathSync(path: TFilePath, options?: IRealpathOptions): TDataOut {
+    realpathSync(path: TFilePath, options?: IRealpathOptions | string): TDataOut {
         return this.realpathBase(pathToFilename(path), getRealpathOptions(options).encoding);
     }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "target": "es5",
+    "lib": ["es5", "dom",  "es2015.promise"],
     "module": "commonjs",
     "removeComments": false,
     "noImplicitAny": false,


### PR DESCRIPTION
Fixes #147 

I saw that you assigned yourself on this issue a while ago but, since it was in may, I took the liberty of implementing it anyway. 

This pull request also ships some unreported bug fixes on which I ran into while testing the promises API. You will find the main fixes in commits de5aca656b58601d563382dbcda3789b06db6b23, be5654b5d8fb5342509033c2513b2c124dcfaadb, and a8c8998038b118cfeec1636238b391a2f4fb16d7.

This implementation warns the user that this is an experimental API, just like Node.js does. But I put the code for this in a different commit (2828f6a9227c1cf077bdd14bca5dd5b6323be2ce), so you can discard it if you don't like it.

I also separated the detection of `Promise` support in the commit 4750aeee53c685afa2194b4aaed21824d8872c19 for the same reason. Basically, if the user tries to use `memfs` promises API in an environment that do not support promises, an exception is thrown.

The API is fully tested. By that I mean all the API features are tested; but, since all functions returning a promise use their non-promise asynchronous counterpart, the tests only consists in checking that they actually return promises, and that those promises resolve or reject in one "standard" use case each. All other use cases should be covered by tests on asynchronous functions of the non-promises API.

Finally, Node.js documentation specifies that:

> [...] if the `FileHandle` is not explicitly closed using the `filehandle.close()` method, they will automatically close the file descriptor and will emit a process warning, thereby helping to prevent memory leaks.

But I don't think its true, at least in the version I currently use (which is 10.11.0). So I did not add such a warning, and I have no idea what its content should be.