### PR TITLE
chore(build): remove unnecessary copy of src/internal

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   ],
   "scripts": {
     "clean": "rimraf lib types",
-    "build": "tsc -p . && cpy src/internal lib/internal",
+    "build": "tsc -p .",
     "test": "jest",
     "test:coverage": "jest --coverage",
     "test:watch": "jest --watch",
@@ -32,7 +32,6 @@
   "devDependencies": {
     "@types/jest": "23.3.10",
     "@types/node": "10.12.10",
-    "cpy-cli": "2.0.0",
     "jest": "21.2.1",
     "rimraf": "2.6.2",
     "semantic-release": "15.12.3",


### PR DESCRIPTION
Fixes #263 

I am not sure why this copy was done, actually. I guess it is legacy code. @streamich, can you confirm that?