### PR TITLE
Fixed constant "fd" value to start from 0x7fffffff instead of 0xffffffff

### DIFF
--- a/src/volume.ts
+++ b/src/volume.ts
@@ -535,7 +535,7 @@ export class Volume {
    * @type {number}
    * @todo This should not be static, right?
    */
-  static fd: number = 0xffffffff;
+  static fd: number = 0x7fffffff;
 
   // Constructor function used to create new nodes.
   // NodeClass: new (...args) => TNode = Node as new (...args) => TNode;


### PR DESCRIPTION
Fixes #274

It's worth to mention that, even though this change does fix the error described in #274, the code in that issue will throw a different error because of the way that tty.WriteStream works internally.

Anyway, it's good to make sure that the file descriptors follow the unix guidelines.