### PR TITLE
feat(volume): add env variable to suppress fs.promise api warnings

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -139,3 +139,11 @@ you get from `require('fs')`. Here are some things this function does:
   ```
 
   - Adds constants `fs.constants`, `fs.F_OK`, etc.
+
+## Experimental fs.promise api warnings
+
+Supress warnings when using the promise api of fs by setting
+
+```js
+process.env['SUPPRESS_EXPERIMENTAL_PROMISE_WARNINGS'] = true;
+```

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -145,5 +145,5 @@ you get from `require('fs')`. Here are some things this function does:
 Supress warnings when using the promise api of fs by setting
 
 ```js
-process.env['SUPPRESS_EXPERIMENTAL_PROMISE_WARNINGS'] = true;
+process.env.MEMFS_DONT_WARN = true;
 ```

--- a/src/__tests__/process.test.ts
+++ b/src/__tests__/process.test.ts
@@ -1,4 +1,4 @@
-import _process, { createProcess } from '../process';
+import _process, { createProcess, SUPPRESS_EXPERIMENTAL_PROMISE_WARNINGS } from '../process';
 
 describe('process', () => {
   describe('createProcess', () => {
@@ -17,5 +17,15 @@ describe('process', () => {
       expect(typeof proc.nextTick).toBe('function');
       proc.nextTick(done);
     });
+    it('.env', () => {
+      expect(typeof proc.env).toBe('object');
+      expect(!!proc.env[SUPPRESS_EXPERIMENTAL_PROMISE_WARNINGS]).toBe(false);
+    });
+  });
+  test('createProcess with env variable', () => {
+    process.env[SUPPRESS_EXPERIMENTAL_PROMISE_WARNINGS] = 'true';
+    const proc = createProcess();
+    expect(!!proc.env[SUPPRESS_EXPERIMENTAL_PROMISE_WARNINGS]).toBe(true);
+    delete process.env[SUPPRESS_EXPERIMENTAL_PROMISE_WARNINGS];
   });
 });

--- a/src/__tests__/process.test.ts
+++ b/src/__tests__/process.test.ts
@@ -1,4 +1,4 @@
-import _process, { createProcess, SUPPRESS_EXPERIMENTAL_PROMISE_WARNINGS } from '../process';
+import _process, { createProcess } from '../process';
 
 describe('process', () => {
   describe('createProcess', () => {
@@ -19,13 +19,13 @@ describe('process', () => {
     });
     it('.env', () => {
       expect(typeof proc.env).toBe('object');
-      expect(!!proc.env[SUPPRESS_EXPERIMENTAL_PROMISE_WARNINGS]).toBe(false);
+      expect(!!proc.env.MEMFS_DONT_WARN).toBe(false);
     });
   });
   test('createProcess with env variable', () => {
-    process.env[SUPPRESS_EXPERIMENTAL_PROMISE_WARNINGS] = 'true';
+    process.env.MEMFS_DONT_WARN = 'true';
     const proc = createProcess();
-    expect(!!proc.env[SUPPRESS_EXPERIMENTAL_PROMISE_WARNINGS]).toBe(true);
-    delete process.env[SUPPRESS_EXPERIMENTAL_PROMISE_WARNINGS];
+    expect(!!proc.env.MEMFS_DONT_WARN).toBe(true);
+    delete process.env.MEMFS_DONT_WARN;
   });
 });

--- a/src/process.ts
+++ b/src/process.ts
@@ -1,11 +1,18 @@
 // Here we mock the global `process` variable in case we are not in Node's environment.
 
+export type SUPPRESS_EXPERIMENTAL_PROMISE_WARNINGS = 'SUPPRESS_EXPERIMENTAL_PROMISE_WARNINGS';
+export const SUPPRESS_EXPERIMENTAL_PROMISE_WARNINGS: SUPPRESS_EXPERIMENTAL_PROMISE_WARNINGS =
+  'SUPPRESS_EXPERIMENTAL_PROMISE_WARNINGS';
+
 export interface IProcess {
   getuid(): number;
   getgid(): number;
   cwd(): string;
   platform: string;
   nextTick: (callback: (...args) => void, ...args) => void;
+  env: {
+    [SUPPRESS_EXPERIMENTAL_PROMISE_WARNINGS]?: boolean;
+  };
 }
 
 export function createProcess(p: IProcess = process): IProcess {
@@ -20,6 +27,7 @@ export function createProcess(p: IProcess = process): IProcess {
   if (!p.getgid) p.getgid = () => 0;
   if (!p.cwd) p.cwd = () => '/';
   if (!p.nextTick) p.nextTick = require('./setImmediate').default;
+  if (!p.env) p.env = {};
   return p;
 }
 

--- a/src/process.ts
+++ b/src/process.ts
@@ -1,9 +1,5 @@
 // Here we mock the global `process` variable in case we are not in Node's environment.
 
-export type SUPPRESS_EXPERIMENTAL_PROMISE_WARNINGS = 'SUPPRESS_EXPERIMENTAL_PROMISE_WARNINGS';
-export const SUPPRESS_EXPERIMENTAL_PROMISE_WARNINGS: SUPPRESS_EXPERIMENTAL_PROMISE_WARNINGS =
-  'SUPPRESS_EXPERIMENTAL_PROMISE_WARNINGS';
-
 export interface IProcess {
   getuid(): number;
   getgid(): number;
@@ -11,7 +7,7 @@ export interface IProcess {
   platform: string;
   nextTick: (callback: (...args) => void, ...args) => void;
   env: {
-    [SUPPRESS_EXPERIMENTAL_PROMISE_WARNINGS]?: boolean;
+    MEMFS_DONT_WARN?: boolean;
   };
 }
 

--- a/src/volume.ts
+++ b/src/volume.ts
@@ -4,7 +4,7 @@ import Stats, { TStatNumber } from './Stats';
 import Dirent from './Dirent';
 import { Buffer } from 'buffer';
 import setImmediate from './setImmediate';
-import process, { SUPPRESS_EXPERIMENTAL_PROMISE_WARNINGS } from './process';
+import process from './process';
 import setTimeoutUnref, { TSetTimeout } from './setTimeoutUnref';
 import { Readable, Writable } from 'stream';
 import { constants } from './constants';
@@ -516,7 +516,7 @@ function validateGid(gid: number) {
 
 // ---------------------------------------- Volume
 
-let promisesWarn = process[SUPPRESS_EXPERIMENTAL_PROMISE_WARNINGS] ? false : true;
+let promisesWarn = !!process.env.MEMFS_DONT_WARN;
 
 /**
  * `Volume` represents a file system.

--- a/src/volume.ts
+++ b/src/volume.ts
@@ -4,7 +4,7 @@ import Stats, { TStatNumber } from './Stats';
 import Dirent from './Dirent';
 import { Buffer } from 'buffer';
 import setImmediate from './setImmediate';
-import process from './process';
+import process, { SUPPRESS_EXPERIMENTAL_PROMISE_WARNINGS } from './process';
 import setTimeoutUnref, { TSetTimeout } from './setTimeoutUnref';
 import { Readable, Writable } from 'stream';
 import { constants } from './constants';
@@ -516,7 +516,7 @@ function validateGid(gid: number) {
 
 // ---------------------------------------- Volume
 
-let promisesWarn = true;
+let promisesWarn = process[SUPPRESS_EXPERIMENTAL_PROMISE_WARNINGS] ? false : true;
 
 /**
  * `Volume` represents a file system.


### PR DESCRIPTION
To suppress experimental fs.promise api warnings the SUPRESS_EXPERIMENTAL_PROMISE_WARNINGS env variable can be set to a truthy value