### PR TITLE
bug(MEMFS_DONT_WARN): node fs.promises experimental warnings should be displayed by default

### DIFF
--- a/src/__tests__/process.test.ts
+++ b/src/__tests__/process.test.ts
@@ -22,10 +22,17 @@ describe('process', () => {
       expect(!!proc.env.MEMFS_DONT_WARN).toBe(false);
     });
   });
-  test('createProcess with env variable', () => {
-    process.env.MEMFS_DONT_WARN = 'true';
-    const proc = createProcess();
-    expect(!!proc.env.MEMFS_DONT_WARN).toBe(true);
-    delete process.env.MEMFS_DONT_WARN;
+  describe('using MEMFS_DONT_WARN', () => {
+    it('should be assignable to the process.env, and returned by createProcess', () => {
+      process.env.MEMFS_DONT_WARN = 'true';
+      const proc = createProcess();
+      expect(!!proc.env.MEMFS_DONT_WARN).toBe(true);
+      delete process.env.MEMFS_DONT_WARN;
+    });
+    it('should by default show warnings (in volume.ts)', () => {
+      const proc = createProcess();
+      const promisesWarn = !proc.env.MEMFS_DONT_WARN;
+      expect(promisesWarn).toBe(true);
+    });
   });
 });

--- a/src/volume.ts
+++ b/src/volume.ts
@@ -516,7 +516,7 @@ function validateGid(gid: number) {
 
 // ---------------------------------------- Volume
 
-let promisesWarn = !!process.env.MEMFS_DONT_WARN;
+let promisesWarn = !process.env.MEMFS_DONT_WARN;
 
 /**
  * `Volume` represents a file system.


### PR DESCRIPTION
additional tests are added and and the default behavior is to display the fs.promise experimental warnings