### PR TITLE
fix: 🐛 throw when creating root directory

### DIFF
--- a/src/__tests__/volume/__snapshots__/mkdirSync.test.ts.snap
+++ b/src/__tests__/volume/__snapshots__/mkdirSync.test.ts.snap
@@ -1,0 +1,5 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`mkdirSync throws when creating root directory 1`] = `"EISDIR: illegal operation on a directory, mkdir"`;
+
+exports[`mkdirSync throws when re-creating existing directory 1`] = `"EEXIST: file already exists, mkdir '/new-dir'"`;

--- a/src/__tests__/volume/__snapshots__/mkdirSync.test.ts.snap
+++ b/src/__tests__/volume/__snapshots__/mkdirSync.test.ts.snap
@@ -1,5 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`mkdirSync throws when creating root directory 1`] = `"EISDIR: illegal operation on a directory, mkdir"`;
+exports[`mkdirSync throws when creating root directory 1`] = `"EISDIR: illegal operation on a directory, mkdir '/'"`;
 
 exports[`mkdirSync throws when re-creating existing directory 1`] = `"EEXIST: file already exists, mkdir '/new-dir'"`;

--- a/src/__tests__/volume/mkdirSync.test.ts
+++ b/src/__tests__/volume/mkdirSync.test.ts
@@ -1,0 +1,53 @@
+import { create } from '../util';
+
+describe('mkdirSync', () => {
+  it('can create a directory', () => {
+    const vol = create();
+
+    vol.mkdirSync('/new-dir');
+    const stat = vol.statSync('/new-dir');
+
+    expect(stat.isDirectory()).toBe(true);
+  });
+
+  it('root directory is directory', () => {
+    const vol = create();
+    const stat = vol.statSync('/');
+
+    expect(stat.isDirectory()).toBe(true);
+  });
+
+  it('throws when re-creating existing directory', () => {
+    const vol = create();
+
+    vol.mkdirSync('/new-dir');
+
+    let error;
+    try {
+      vol.mkdirSync('/new-dir');
+    } catch (err) {
+      error = err;
+    }
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error.message).toMatchSnapshot();
+  });
+
+  /**
+   * See issue #325
+   * https://github.com/streamich/memfs/issues/325
+   */
+  it('throws when creating root directory', () => {
+    const vol = create();
+
+    let error;
+    try {
+      vol.mkdirSync('/');
+    } catch (err) {
+      error = err;
+    }
+
+    expect(error).toBeInstanceOf(Error);
+    expect(error.message).toMatchSnapshot();
+  });
+});

--- a/src/volume.ts
+++ b/src/volume.ts
@@ -1771,7 +1771,7 @@ export class Volume {
 
     // This will throw if user tries to create root dir `fs.mkdirSync('/')`.
     if (!steps.length) {
-      throwError(EISDIR, 'mkdir');
+      throwError(EISDIR, 'mkdir', filename);
     }
 
     const dir = this.getLinkParentAsDirOrThrow(filename, 'mkdir');

--- a/src/volume.ts
+++ b/src/volume.ts
@@ -1768,6 +1768,12 @@ export class Volume {
 
   private mkdirBase(filename: string, modeNum: number) {
     const steps = filenameToSteps(filename);
+
+    // This will throw if user tries to create root dir `fs.mkdirSync('/')`.
+    if (!steps.length) {
+      throwError(EISDIR, 'mkdir');
+    }
+
     const dir = this.getLinkParentAsDirOrThrow(filename, 'mkdir');
 
     // Check path already exists.


### PR DESCRIPTION
closes #325