### PR TITLE
[WIP] watch fires callbacks multiple times. 

### DIFF
--- a/src/__tests__/watch.test.ts
+++ b/src/__tests__/watch.test.ts
@@ -1,0 +1,21 @@
+import { Volume } from '../volume';
+
+describe("watching files", () => {
+  it("Should only call the watcher once on .writeFile", done => {
+    const spy = jest.fn();
+    const vol = new Volume();
+    vol.writeFileSync('/watcher.txt', '1');
+    let count = 1;
+    vol.watch('/watcher.txt', (...args) => {
+      console.log("watched updated", count++, new Error().stack);
+      return spy(...args);
+    });
+    
+    // update some content
+    vol.writeFileSync("/watcher.txt", "2");
+    setTimeout(() => {
+      expect(spy).toHaveBeenCalledTimes(1);
+    }, 2500);
+  
+  });
+});

--- a/src/volume.ts
+++ b/src/volume.ts
@@ -2085,24 +2085,31 @@ export class Volume {
     return new this.WriteStream(path, options);
   }
 
-  // watch(path: TFilePath): FSWatcher;
-  // watch(path: TFilePath, options?: IWatchOptions | string): FSWatcher;
-  watch(
-    path: TFilePath,
-    options?: IWatchOptions | string,
-    listener?: (eventType: string, filename: string) => void,
-  ): FSWatcher {
+  watch(path: TFilePath, listener?: (eventType: string, filename: string) => void,): FSWatcher;
+  watch(path: TFilePath, options?: IWatchOptions | string, listener?: (eventType: string, filename: string) => void ): FSWatcher 
+  watch(path: TFilePath, a, b?): FSWatcher {
     const filename = pathToFilename(path);
 
+    let options: IWatchOptions = a;
+    let listener: (eventType: string, filename: string) => void = b;
+
     if (typeof options === 'function') {
-      listener = options;
+      listener = a;
       options = null;
+    }
+
+    if (typeof listener !== 'function') {
+      throw Error('"watch()" requires a listener function');
     }
 
     // tslint:disable-next-line prefer-const
     let { persistent, recursive, encoding }: IWatchOptions = getDefaultOpts(options);
-    if (persistent === undefined) persistent = true;
-    if (recursive === undefined) recursive = false;
+    if (persistent === undefined) {
+      persistent = true;
+    }
+    if (recursive === undefined) {
+      recursive = false;
+    }
 
     const watcher = new this.FSWatcher();
     watcher.start(filename, persistent, recursive, encoding as TEncoding);


### PR DESCRIPTION
This is a follow up from my watch tests on `unionfs` a couple of weeks ago, I've isolated the problem in a small test but I couldn't think best how to solve it with the current `Volume`, `File`, `Node` storage. 

The issue comes when calling `writeFile` which subsequently calls both `openFile` to get the file descriptor and then `write` to commit the change. 

Internally both of these call `touch` on the node, emitting a change event. However on with node's real filesystem this is not the case and I assume these are wrapped in some kind of transaction. 

Stack which you get back when you run the test case. 

**Any ideas of how we can fix this bug?**

```
console.log src/__tests__/watch.test.ts:10
    watched updated 1 Error
        at FSWatcher.<anonymous> (/dev/streamich/memfs/src/__tests__/watch.test.ts:10:47)
        at emitTwo (events.js:126:13)
        at FSWatcher.emit (events.js:214:7)
        at FSWatcher._this._emit (/dev/streamich/memfs/src/volume.ts:2534:10)
        at Node.FSWatcher._this._onNodeChange (/dev/streamich/memfs/src/volume.ts:2524:10)
        at emitOne (events.js:116:13)
        at Node.emit (events.js:211:7)
        at Node.Object.<anonymous>.Node.touch (/dev/streamich/memfs/src/node.ts:167:10)
        at Node.Object.<anonymous>.Node.truncate (/dev/streamich/memfs/src/node.ts:150:10)
        at File.Object.<anonymous>.File.truncate (/dev/streamich/memfs/src/node.ts:412:15)
        at Volume.Object.<anonymous>.Volume.openLink (/dev/streamich/memfs/src/volume.ts:920:34)
        at Volume.Object.<anonymous>.Volume.openFile (/dev/streamich/memfs/src/volume.ts:941:27)
        at Volume.Object.<anonymous>.Volume.openBase (/dev/streamich/memfs/src/volume.ts:946:23)
        at Volume.Object.<anonymous>.Volume.writeFileBase (/dev/streamich/memfs/src/volume.ts:1221:17)
        at Volume.Object.<anonymous>.Volume.writeFileSync (/dev/streamich/memfs/src/volume.ts:1245:10)
        at Object.<anonymous> (/dev/streamich/memfs/src/__tests__/watch.test.ts:15:9)
        at resolve (/dev/streamich/memfs/node_modules/jest-jasmine2/build/queueRunner.js:41:12)
        at new Promise (<anonymous>)
        at mapper (/dev/streamich/memfs/node_modules/jest-jasmine2/build/queueRunner.js:26:19)
        at promise.then (/dev/streamich/memfs/node_modules/jest-jasmine2/build/queueRunner.js:71:41)
        at <anonymous>

  console.log src/__tests__/watch.test.ts:10
    watched updated 2 Error
        at FSWatcher.<anonymous> (/dev/streamich/memfs/src/__tests__/watch.test.ts:10:47)
        at emitTwo (events.js:126:13)
        at FSWatcher.emit (events.js:214:7)
        at FSWatcher._this._emit (/dev/streamich/memfs/src/volume.ts:2534:10)
        at Node.FSWatcher._this._onNodeChange (/dev/streamich/memfs/src/volume.ts:2524:10)
        at emitOne (events.js:116:13)
        at Node.emit (events.js:211:7)
        at Node.Object.<anonymous>.Node.touch (/dev/streamich/memfs/src/node.ts:167:10)
        at Node.Object.<anonymous>.Node.write (/dev/streamich/memfs/src/node.ts:116:10)
        at File.Object.<anonymous>.File.write (/dev/streamich/memfs/src/node.ts:426:29)
        at Volume.Object.<anonymous>.Volume.writeBase (/dev/streamich/memfs/src/volume.ts:1092:17)
        at Volume.Object.<anonymous>.Volume.writeSync (/dev/streamich/memfs/src/volume.ts:1126:17)
        at Volume.Object.<anonymous>.Volume.writeFileBase (/dev/streamich/memfs/src/volume.ts:1230:30)
        at Volume.Object.<anonymous>.Volume.writeFileSync (/dev/streamich/memfs/src/volume.ts:1245:10)
        at Object.<anonymous> (/dev/streamich/memfs/src/__tests__/watch.test.ts:15:9)
        at resolve (/dev/streamich/memfs/node_modules/jest-jasmine2/build/queueRunner.js:41:12)
        at new Promise (<anonymous>)
        at mapper (/dev/streamich/memfs/node_modules/jest-jasmine2/build/queueRunner.js:26:19)
        at promise.then (/dev/streamich/memfs/node_modules/jest-jasmine2/build/queueRunner.js:71:41)
        at <anonymous>
```