### PR TITLE
fix: 🐛 accept `null` as value in `fromJSON` functions

### DIFF
--- a/src/volume.ts
+++ b/src/volume.ts
@@ -808,7 +808,7 @@ export class Volume {
     });
   }
 
-  private _toJSON(link = this.root, json = {}, path?: string) {
+  private _toJSON(link = this.root, json = {}, path?: string): DirectoryJSON {
     let isEmpty = true;
 
     for (const name in link.children) {
@@ -836,7 +836,7 @@ export class Volume {
     return json;
   }
 
-  toJSON(paths?: TFilePath | TFilePath[], json = {}, isRelative = false) {
+  toJSON(paths?: TFilePath | TFilePath[], json = {}, isRelative = false): DirectoryJSON {
     const links: Link[] = [];
 
     if (paths) {

--- a/src/volume.ts
+++ b/src/volume.ts
@@ -518,11 +518,13 @@ function validateGid(gid: number) {
 
 let promisesWarn = !process.env.MEMFS_DONT_WARN;
 
+type DirectoryJSON = Record<string, string | null>;
+
 /**
  * `Volume` represents a file system.
  */
 export class Volume {
-  static fromJSON(json: { [filename: string]: string }, cwd?: string): Volume {
+  static fromJSON(json: DirectoryJSON, cwd?: string): Volume {
     const vol = new Volume();
     vol.fromJSON(json, cwd);
     return vol;
@@ -855,7 +857,7 @@ export class Volume {
   }
 
   // fromJSON(json: {[filename: string]: string}, cwd: string = '/') {
-  fromJSON(json: { [filename: string]: string }, cwd: string = process.cwd()) {
+  fromJSON(json: DirectoryJSON, cwd: string = process.cwd()) {
     for (let filename in json) {
       const data = json[filename];
 
@@ -886,7 +888,7 @@ export class Volume {
   }
 
   // Legacy interface
-  mountSync(mountpoint: string, json: { [filename: string]: string }) {
+  mountSync(mountpoint: string, json: DirectoryJSON) {
     this.fromJSON(json, mountpoint);
   }
 

--- a/src/volume.ts
+++ b/src/volume.ts
@@ -518,7 +518,7 @@ function validateGid(gid: number) {
 
 let promisesWarn = !process.env.MEMFS_DONT_WARN;
 
-type DirectoryJSON = Record<string, string | null>;
+export type DirectoryJSON = Record<string, string | null>;
 
 /**
  * `Volume` represents a file system.


### PR DESCRIPTION
I created the `DirectoryJSON` alias just to make things easier.

I looked at enabled `strictNullChecks`, but this package just wasn't designed for it :joy:
Ideally, it'd be good to have it on at some point, or otherwise ensure all methods that can return `null` or `undefined` as thusly typed.

I've not linked the issue with this PR, as the issue could be used to track the above, and this is the change that I need ASAP to continue work on my current project.

Once I have some time, I'll be happy to look into making this library more `strictNullChecks` compatible.