### PR TITLE
feat: allow exporting file paths in Volume.toJSON

### DIFF
--- a/src/__tests__/volume.test.ts
+++ b/src/__tests__/volume.test.ts
@@ -130,6 +130,18 @@ describe('volume', () => {
         });
       });
 
+      it('Specify a file export path', () => {
+        const vol = Volume.fromJSON({
+          '/foo': 'bar',
+          '/dir/a': 'b',
+          '/dir2/a': 'b',
+          '/dir2/c': 'd',
+        });
+        expect(vol.toJSON(['/dir/a'])).toEqual({
+          '/dir/a': 'b',
+        });
+      });
+
       it('Accumulate exports on supplied object', () => {
         const vol = Volume.fromJSON({
           '/foo': 'bar',

--- a/src/volume.ts
+++ b/src/volume.ts
@@ -809,7 +809,14 @@ export class Volume {
   private _toJSON(link = this.root, json = {}, path?: string) {
     let isEmpty = true;
 
-    for (const name in link.children) {
+    let children = link.children;
+
+    if (link.getNode().isFile()) {
+      children = { [link.getName()]: link.parent.getChild(link.getName()) };
+      link = link.parent;
+    }
+
+    for (const name in children) {
       isEmpty = false;
 
       const child = link.getChild(name);


### PR DESCRIPTION
This allows files path to be specified in `Volume.toJSON`. Without this patch, files specificed would show up in the resulting `JSON`, but with its contets set to `null`.

Test is included.