### PR TITLE
fix: check for process

### DIFF
--- a/src/process.ts
+++ b/src/process.ts
@@ -12,7 +12,8 @@ export interface IProcess {
   };
 }
 
-export function createProcess(p: IProcess = process): IProcess {
+export function createProcess(): IProcess {
+  let p: IProcess = typeof process !== 'undefined' && process;
   if (!p) {
     try {
       p = require('process');


### PR DESCRIPTION
Fixes this issue when running in the browser:

```
process.js:5 Uncaught ReferenceError: process is not defined
    at createProcess (process.js:5)
    at Object../node_modules/memfs/lib/process.js (process.js:32)
    at __webpack_require__ (bootstrap:19)
    at Object.<anonymous> (node.js:16)
    at Object../node_modules/memfs/lib/node.js (node.js:405)
    at __webpack_require__ (bootstrap:19)
    at Object../node_modules/memfs/lib/volume.js (volume.js:17)
    at __webpack_require__ (bootstrap:19)
    at Object../node_modules/memfs/lib/index.js (index.js:16)
    at __webpack_require__ (bootstrap:19)
```