### PR TITLE
refactor: `createProcess` fn to be compatible w/ `strictNullChecks`

### DIFF
--- a/src/process.ts
+++ b/src/process.ts
@@ -2,8 +2,11 @@
 
 export interface IProcess {
   getuid(): number;
+
   getgid(): number;
+
   cwd(): string;
+
   platform: string;
   nextTick: (callback: (...args) => void, ...args) => void;
   emitWarning: (message: string, type: string) => void;
@@ -12,14 +15,30 @@ export interface IProcess {
   };
 }
 
-export function createProcess(): IProcess {
-  let p: IProcess = typeof process !== 'undefined' && process;
-  if (!p) {
-    try {
-      p = require('process');
-    } catch (e) {}
+/**
+ * Looks to return a `process` object, if one is available.
+ *
+ * The global `process` is returned if defined;
+ * otherwise `require('process')` is attempted.
+ *
+ * If that fails, `undefined` is returned.
+ *
+ * @return {IProcess | undefined}
+ */
+const maybeReturnProcess = (): IProcess | undefined => {
+  if (typeof process !== 'undefined') {
+    return process;
   }
-  if (!p) p = {} as IProcess;
+
+  try {
+    return require('process');
+  } catch {
+    return undefined;
+  }
+};
+
+export function createProcess(): IProcess {
+  const p: IProcess = maybeReturnProcess() || ({} as IProcess);
 
   if (!p.getuid) p.getuid = () => 0;
   if (!p.getgid) p.getgid = () => 0;


### PR DESCRIPTION
This makes the `createProcess` function safer, so that it's compatible w/ `strictNullChecks`.

Merging this will mean #409 will start passing the tests, but I've opted to merge it directly into master instead of that branch or `next` b/c it shouldn't be breaking nor released.

This just means we can tie this loose end away early :)

Personally, I'm interested in what this method is doing - it looks to be mainly for mocking in tests; otherwise it does modify the global `process` *if* it's defined (which I think it might be for browsers as a polyfill, but even...)

I think it might be useful to refactor the dependency on `process` down to a single point by using a SSOT  wrapper:

```
// processInfoProvider.ts
const getProcess = (): IProcess => {
  /* do whatever */
};

// if we think the underlying object might somehow be changed,
// then this can be replaced w/ direct calls to getProcess()
const theProcess = getProcess();

export const getuid = () => theProcess.getuid();
export const getgid = () => theProcess.getgid();
export const cwd = () => theProcess.cwd();
export const nextTick = () => theProcess.nextTick;

/* ... etc ... */

// later...
import * as processInfo from 'processInfoProvider';

const uid = processInfo .getuid();
```

This also means we're not dependent on a global.

Ideally, it'd be nice to be able to remove things like setImmediate`, and just leave it up to Node/Webpack/Babel/<polyfiller>, but the above would be a good start and mean only that file would need to be changed to adjust anything related to `process`.