### PR TITLE
Polyfill Buffer for Node v0.11+

### DIFF
--- a/src/encoding.ts
+++ b/src/encoding.ts
@@ -1,3 +1,4 @@
+import { Buffer } from './internal/buffer';
 import * as errors from './internal/errors';
 
 export type TDataOut = string | Buffer; // Data formats we give back to users.

--- a/src/internal/buffer.ts
+++ b/src/internal/buffer.ts
@@ -1,0 +1,10 @@
+import { Buffer } from 'buffer';
+
+function bufferV0P12Ponyfill(arg0: any, ...args: any): Buffer {
+  return new Buffer(arg0, ...args);
+}
+
+const bufferAllocUnsafe = Buffer.allocUnsafe || bufferV0P12Ponyfill;
+const bufferFrom = Buffer.from || bufferV0P12Ponyfill;
+
+export { Buffer, bufferAllocUnsafe, bufferFrom };

--- a/src/node.ts
+++ b/src/node.ts
@@ -1,4 +1,5 @@
 import process from './process';
+import { bufferAllocUnsafe, bufferFrom } from './internal/buffer';
 import { constants, S } from './constants';
 import { Volume } from './volume';
 import { EventEmitter } from 'events';
@@ -49,18 +50,18 @@ export class Node extends EventEmitter {
   }
 
   setString(str: string) {
-    // this.setBuffer(Buffer.from(str, 'utf8'));
-    this.buf = Buffer.from(str, 'utf8');
+    // this.setBuffer(bufferFrom(str, 'utf8'));
+    this.buf = bufferFrom(str, 'utf8');
     this.touch();
   }
 
   getBuffer(): Buffer {
-    if (!this.buf) this.setBuffer(Buffer.allocUnsafe(0));
-    return Buffer.from(this.buf); // Return a copy.
+    if (!this.buf) this.setBuffer(bufferAllocUnsafe(0));
+    return bufferFrom(this.buf); // Return a copy.
   }
 
   setBuffer(buf: Buffer) {
-    this.buf = Buffer.from(buf); // Creates a copy of data.
+    this.buf = bufferFrom(buf); // Creates a copy of data.
     this.touch();
   }
 
@@ -103,10 +104,10 @@ export class Node extends EventEmitter {
   }
 
   write(buf: Buffer, off: number = 0, len: number = buf.length, pos: number = 0): number {
-    if (!this.buf) this.buf = Buffer.allocUnsafe(0);
+    if (!this.buf) this.buf = bufferAllocUnsafe(0);
 
     if (pos + len > this.buf.length) {
-      const newBuf = Buffer.allocUnsafe(pos + len);
+      const newBuf = bufferAllocUnsafe(pos + len);
       this.buf.copy(newBuf, 0, 0, this.buf.length);
       this.buf = newBuf;
     }
@@ -120,7 +121,7 @@ export class Node extends EventEmitter {
 
   // Returns the number of bytes read.
   read(buf: Buffer | Uint8Array, off: number = 0, len: number = buf.byteLength, pos: number = 0): number {
-    if (!this.buf) this.buf = Buffer.allocUnsafe(0);
+    if (!this.buf) this.buf = bufferAllocUnsafe(0);
 
     let actualLen = len;
     if (actualLen > buf.byteLength) {
@@ -135,13 +136,13 @@ export class Node extends EventEmitter {
   }
 
   truncate(len: number = 0) {
-    if (!len) this.buf = Buffer.allocUnsafe(0);
+    if (!len) this.buf = bufferAllocUnsafe(0);
     else {
-      if (!this.buf) this.buf = Buffer.allocUnsafe(0);
+      if (!this.buf) this.buf = bufferAllocUnsafe(0);
       if (len <= this.buf.length) {
         this.buf = this.buf.slice(0, len);
       } else {
-        const buf = Buffer.allocUnsafe(0);
+        const buf = bufferAllocUnsafe(0);
         this.buf.copy(buf);
         buf.fill(0, len);
       }

--- a/src/promises.ts
+++ b/src/promises.ts
@@ -16,6 +16,7 @@ import {
   IWriteFileOptions,
   IStatOptions,
 } from './volume';
+import { Buffer } from './internal/buffer';
 import Stats from './Stats';
 import Dirent from './Dirent';
 import { TDataOut } from './encoding';

--- a/src/volume.ts
+++ b/src/volume.ts
@@ -2,7 +2,7 @@ import * as pathModule from 'path';
 import { Node, Link, File } from './node';
 import Stats, { TStatNumber } from './Stats';
 import Dirent from './Dirent';
-import { Buffer } from 'buffer';
+import { Buffer, bufferAllocUnsafe, bufferFrom } from './internal/buffer';
 import setImmediate from './setImmediate';
 import process from './process';
 import setTimeoutUnref, { TSetTimeout } from './setTimeoutUnref';
@@ -427,14 +427,14 @@ export function pathToSteps(path: TFilePath): string[] {
 
 export function dataToStr(data: TData, encoding: string = ENCODING_UTF8): string {
   if (Buffer.isBuffer(data)) return data.toString(encoding);
-  else if (data instanceof Uint8Array) return Buffer.from(data).toString(encoding);
+  else if (data instanceof Uint8Array) return bufferFrom(data).toString(encoding);
   else return String(data);
 }
 
 export function dataToBuffer(data: TData, encoding: string = ENCODING_UTF8): Buffer {
   if (Buffer.isBuffer(data)) return data;
-  else if (data instanceof Uint8Array) return Buffer.from(data);
-  else return Buffer.from(String(data), encoding);
+  else if (data instanceof Uint8Array) return bufferFrom(data);
+  else return bufferFrom(String(data), encoding);
 }
 
 export function bufferToEncoding(buffer: Buffer, encoding?: TEncodingExtended): TDataOut {
@@ -2185,7 +2185,7 @@ export interface IReadStream extends Readable {
 var pool;
 
 function allocNewPool(poolSize) {
-  pool = Buffer.allocUnsafe(poolSize);
+  pool = bufferAllocUnsafe(poolSize);
   pool.used = 0;
 }
 


### PR DESCRIPTION
This change adds a loose ponyfill for `Buffer.from` and `Buffer.allocUnsafe`, written for the usage in this package. This extends the compatibility of this project from Node v5.10 to Node v0.11.

The motivation to make such a change is to support legacy systems — often hosting platforms reliant on Node v0.12 — without unnecessarily inflating or complicating the source code, or reducing its performance.

This change addresses your request in #421 that the ponyfill be embedded rather than imported as a dependency. Credit for identifying the compatibility issue goes to @rangoo94 — thank you so much!

- Resolves #421
- Resolves #419

---

**About the strategy of this ponyfill**:

The strategy used by this ponyfill follows a convention that I observed in this project to prefer use of the spread operator. In doing so, TypeScript will prefer an explicit first argument.

```ts
function bufferV0P12Ponyfill(arg0: any, ...args: any): Buffer {
  return new Buffer(arg0, ...args);
}
```

An alternative would be to bind the arguments using `Function.bind`. I did not do this, because it would reduce the readability of the source. A benefit to this alternative would be a smaller filesize, as this alternative would not require babel transformation.

```ts
function bufferV0P12Polyfill(): Buffer {
  return new (Function.bind.apply(Buffer, Array.prototype.concat.apply([null], arguments)))();
}
```