### PR TITLE
Omit promises warning before actual use

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,10 @@ export function createFsFromVolume(vol: _Volume): IFs {
   for (const method of fsSyncMethods) if (typeof vol[method] === 'function') fs[method] = vol[method].bind(vol);
   for (const method of fsAsyncMethods) if (typeof vol[method] === 'function') fs[method] = vol[method].bind(vol);
 
+  const HAS_MEMFS_DONT_WARN = 'MEMFS_DONT_WARN' in process.env;
+  const MEMFS_DONT_WARN = process.env.MEMFS_DONT_WARN;
+  process.env.MEMFS_DONT_WARN = 'true';
+
   fs.StatWatcher = vol.StatWatcher;
   fs.FSWatcher = vol.FSWatcher;
   fs.WriteStream = vol.WriteStream;
@@ -37,6 +41,12 @@ export function createFsFromVolume(vol: _Volume): IFs {
   fs.promises = vol.promises;
 
   fs._toUnixTimestamp = toUnixTimestamp;
+
+  if (HAS_MEMFS_DONT_WARN) {
+    process.env.MEMFS_DONT_WARN = MEMFS_DONT_WARN;
+  } else {
+    delete process.env.MEMFS_DONT_WARN;
+  }
 
   return fs;
 }

--- a/src/volume.ts
+++ b/src/volume.ts
@@ -516,7 +516,7 @@ function validateGid(gid: number) {
 
 // ---------------------------------------- Volume
 
-let promisesWarn = !process.env.MEMFS_DONT_WARN;
+let promisesWarn = true;
 
 export type DirectoryJSON = Record<string, string | null>;
 
@@ -582,9 +582,11 @@ export class Volume {
   private promisesApi = createPromisesApi(this);
 
   get promises() {
-    if (promisesWarn) {
-      promisesWarn = false;
-      process.emitWarning('The fs.promises API is experimental', 'ExperimentalWarning');
+    if (!process.env.MEMFS_DONT_WARN) {
+      if (promisesWarn) {
+        promisesWarn = false;
+        process.emitWarning('The fs.promises API is experimental', 'ExperimentalWarning');
+      }
     }
     if (this.promisesApi === null) throw new Error('Promise is not supported in this environment.');
     return this.promisesApi;


### PR DESCRIPTION
This change allows the creation of new volumes without emitting a promises warning. The warning is still omitted when the `promises` property is accessed for the first time on the volume itself, as expected.

---

This **should** emit a warning:

```js
const { Volume } = require('memfs');

const fs = new Volume();

console.log(fs.promises);
```

This **should not** emit a warning:

```js
const { Volume } = require('memfs');

const fs = new Volume();
```

---

**About the "true" string**:

```js
process.env.MEMFS_DONT_WARN = 'true';
```

The string `"true"` is used over the boolean `true` in order to respect the typings of `process.env`.