### PR TITLE
Fix statBase, realpathBase and getChild

### DIFF
--- a/src/node.ts
+++ b/src/node.ts
@@ -301,7 +301,9 @@ export class Link extends EventEmitter {
   }
 
   getChild(name: string): Link {
-    return this.children[name];
+    if (Object.hasOwnProperty.call(this.children, name)) {
+      return this.children[name];
+    }
   }
 
   getPath(): string {

--- a/src/volume.ts
+++ b/src/volume.ts
@@ -1459,11 +1459,7 @@ export class Volume {
   private statBase(filename: string, bigint: false): Stats<number>;
   private statBase(filename: string, bigint: true): Stats<bigint>;
   private statBase(filename: string, bigint: boolean = false): Stats {
-    let link: Link = this.getLink(filenameToSteps(filename));
-    if (!link) throwError(ENOENT, 'stat', filename);
-
-    // Resolve symlinks.
-    link = this.resolveSymlinks(link);
+    const link = this.getResolvedLink(filenameToSteps(filename));
     if (!link) throwError(ENOENT, 'stat', filename);
 
     return Stats.build(link.getNode(), bigint);

--- a/src/volume.ts
+++ b/src/volume.ts
@@ -1410,12 +1410,7 @@ export class Volume {
 
   private realpathBase(filename: string, encoding: TEncodingExtended): TDataOut {
     const steps = filenameToSteps(filename);
-    const link: Link = this.getLink(steps);
-    // TODO: this check has to be perfomed by `lstat`.
-    if (!link) throwError(ENOENT, 'realpath', filename);
-
-    // Resolve symlinks.
-    const realLink = this.resolveSymlinks(link);
+    const realLink = this.getResolvedLink(steps);
     if (!realLink) throwError(ENOENT, 'realpath', filename);
 
     return strToEncoding(realLink.getPath(), encoding);


### PR DESCRIPTION
Why this pr:

1. statBase, realpathBase

`/a/b/index.js` if b is a symlink, stat, realpath function will fail

2. getChild

`/a/toString` if path includes `toString`, it will fail

I fork this repo and publish `memfs-nodebowl` for https://github.com/nodebowl/nodebowl, when this pr merge and publish, I will change it to `memfs`.