### PR TITLE
fix(watch): trigger change event on a folder when children are added/deleted

### DIFF
--- a/src/volume.ts
+++ b/src/volume.ts
@@ -2563,6 +2563,9 @@ export class FSWatcher extends EventEmitter {
 
     this._link.getNode().on('change', this._onNodeChange);
 
+    this._link.on('child:add', this._onNodeChange);
+    this._link.on('child:delete', this._onNodeChange);
+
     const parent = this._link.parent;
     if (parent) {
       // parent.on('child:add', this._onParentChild);


### PR DESCRIPTION
Hey there,

In node's `fs`, when doing `fs.watch` on a folder, the listener is triggered when files are added or deleted from that folder. This PR mirrors this behaviour for memfs as well.

I did not add tests because I could not find any tests for `watch`. I'd be happy to write some, but feel this might be out of scope for this PR? Let me know what you think.

Thanks!
