### PR TITLE
fix(watch): suppress event-emitter warnings

### DIFF
--- a/src/volume.ts
+++ b/src/volume.ts
@@ -2566,6 +2566,7 @@ export class FSWatcher extends EventEmitter {
     const parent = this._link.parent;
     if (parent) {
       // parent.on('child:add', this._onParentChild);
+      parent.setMaxListeners(parent.getMaxListeners() + 1);
       parent.on('child:delete', this._onParentChild);
     }
 


### PR DESCRIPTION
Hello again :)

So, before this patch - if we were watching more than 11 files in the same folder, we'd get warnings like these:
```
(node:13033) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 child:delete listeners added to [Link]. Use emitter.setMaxListeners() to increase limit
```

This was because the `FSWatcher` would listen to the parent delete event to know when to emit a `rename` event for this node. Since in this case this is clearly not a memory leak, I think it makes sense to just increase the limit by 1 before adding the watcher. Let me know if you think differently and I'll try to find a different solution.

As mentioned in https://github.com/streamich/memfs/pull/485, I'd be happy to write some tests for `watch` that will include testing this functionality.