### PR TITLE
Use object assign instead of fast extend

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,9 @@
     },
     "testRegex": ".*/__tests__/.*\\.(test|spec)\\.(jsx?|tsx?)$"
   },
+  "engines": {
+    "node": ">= 8.3.0"
+  },
   "release": {
     "verifyConditions": [
       "@semantic-release/changelog",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "testRegex": ".*/__tests__/.*\\.(test|spec)\\.(jsx?|tsx?)$"
   },
   "engines": {
-    "node": ">= 8.3.0"
+    "node": ">= 4.0.0"
   },
   "release": {
     "verifyConditions": [

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "url": "https://github.com/streamich/memfs.git"
   },
   "dependencies": {
-    "fast-extend": "1.0.2",
     "fs-monkey": "0.3.3"
   },
   "devDependencies": {

--- a/src/volume.ts
+++ b/src/volume.ts
@@ -12,7 +12,6 @@ import { constants } from './constants';
 import { EventEmitter } from 'events';
 import { TEncodingExtended, TDataOut, assertEncoding, strToEncoding, ENCODING_UTF8 } from './encoding';
 import * as errors from './internal/errors';
-const { extend } = require('fast-extend');
 import util = require('util');
 import createPromisesApi from './promises';
 
@@ -215,10 +214,10 @@ function getOptions<T extends IOptions>(defaults: T, options?: T | string): T {
     const tipeof = typeof options;
     switch (tipeof) {
       case 'string':
-        opts = extend({}, defaults, { encoding: options as string });
+        opts = Object.assign({}, defaults, { encoding: options as string });
         break;
       case 'object':
-        opts = extend({}, defaults, options);
+        opts = Object.assign({}, defaults, options);
         break;
       default:
         throw TypeError(ERRSTR_OPTS(tipeof));
@@ -339,8 +338,8 @@ const mkdirDefaults: IMkdirOptions = {
   recursive: false,
 };
 const getMkdirOptions = (options): IMkdirOptions => {
-  if (typeof options === 'number') return extend({}, mkdirDefaults, { mode: options });
-  return extend({}, mkdirDefaults, options);
+  if (typeof options === 'number') return Object.assign({}, mkdirDefaults, { mode: options });
+  return Object.assign({}, mkdirDefaults, options);
 };
 
 // Options for `fs.rmdir` and `fs.rmdirSync`
@@ -351,7 +350,7 @@ const rmdirDefaults: IRmdirOptions = {
   recursive: false,
 };
 const getRmdirOptions = (options): IRmdirOptions => {
-  return extend({}, rmdirDefaults, options);
+  return Object.assign({}, rmdirDefaults, options);
 };
 
 // Options for `fs.readdir` and `fs.readdirSync`
@@ -372,7 +371,7 @@ export interface IStatOptions {
 const statDefaults: IStatOptions = {
   bigint: false,
 };
-const getStatOptions: (options?: any) => IStatOptions = (options = {}) => extend({}, statDefaults, options);
+const getStatOptions: (options?: any) => IStatOptions = (options = {}) => Object.assign({}, statDefaults, options);
 const getStatOptsAndCb: (options: any, callback?: TCallback<Stats>) => [IStatOptions, TCallback<Stats>] = (
   options,
   callback?,
@@ -579,7 +578,7 @@ export class Volume {
   }
 
   constructor(props = {}) {
-    this.props = extend({ Node, Link, File }, props);
+    this.props = Object.assign({ Node, Link, File }, props);
 
     const root = this.createLink();
     root.setNode(this.createNode(true));
@@ -2228,7 +2227,7 @@ function FsReadStream(vol, path, options) {
   this._vol = vol;
 
   // a little bit bigger buffer and water marks by default
-  options = extend({}, getOptions(options, {}));
+  options = Object.assign({}, getOptions(options, {}));
   if (options.highWaterMark === undefined) options.highWaterMark = 64 * 1024;
 
   Readable.call(this, options);
@@ -2390,7 +2389,7 @@ function FsWriteStream(vol, path, options) {
   if (!(this instanceof FsWriteStream)) return new (FsWriteStream as any)(vol, path, options);
 
   this._vol = vol;
-  options = extend({}, getOptions(options, {}));
+  options = Object.assign({}, getOptions(options, {}));
 
   Writable.call(this, options);
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": ["es5", "dom", "es2015.promise"],
+    "lib": ["ES2017", "dom"],
     "module": "commonjs",
     "removeComments": false,
     "noImplicitAny": false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2183,11 +2183,6 @@ fast-deep-equal@^2.0.1:
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49"
   integrity sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=
 
-fast-extend@1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/fast-extend/-/fast-extend-1.0.2.tgz#3b8a5b09cbc8ff3d6d47eaf397398c0a643e441b"
-  integrity sha512-XXA9RmlPatkFKUzqVZAFth18R4Wo+Xug/S+C7YlYA3xrXwfPlW3dqNwOb4hvQo7wZJ2cNDYhrYuPzVOfHy5/uQ==
-
 fast-glob@^2.2.6:
   version "2.2.7"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-2.2.7.tgz#6953857c3afa475fff92ee6015d52da70a4cd39d"


### PR DESCRIPTION
Because I like looking at really tiny numbers that don't matter in the real world, I did a micro benchmark of `fast-extend` vs `Object.assign` & spread:

```
extend 0.0065383616383615385
assign 0.003307592407592418
spread 0.003464735264735254
```

`Object.assign` consistently performs hits 0.003 while extend only ever gets as good as 0.004 every so often - it's most consistently at 0.005 if not higher.

However, `Object.assign` is Node 4 & above, and while `travis` tests against 8+, the engines field isn't in the `package.json`.

Hence, I've set the engine field in this PR: I think it's fine to not make this a major release, since 8 itself is EOL, and previous conversations have mentioned that we're only wanting to support the latest version of FS as it's otherwise too much overhead.

This should also mean that renovate will stop hitting us with PRs for majors that remove support for node8 🎉 

<details>
<summary>code used for performance test</summary>

```
const { PerformanceObserver, performance } = require('perf_hooks');

const { extend } = require('fast-extend');
const times = {
  extend: [],
  assign: [],
  spread: [],
};
const obs = new PerformanceObserver(list => {
  const entries = list.getEntries();

  entries.forEach(entry => times[entry.name].push(entry.duration));
});

obs.observe({ entryTypes: ['function', 'measure'] });

const loops = 1000;

const b = { bigint: true, p: {} };
const c = { bigint: false, p: { mine: 'hello' }, c: {}, def: {} };

for (let i = 0; i < loops; i++) {
  performance.mark(`extend:${i}:start`);
  extend({}, b, c);
  performance.mark(`extend:${i}:stop`);
}

for (let i = 0; i < loops; i++) {
  performance.mark(`assign:${i}:start`);
  Object.assign({}, b, c);
  performance.mark(`assign:${i}:stop`);
}

for (let i = 0; i < loops; i++) {
  performance.mark(`spread:${i}:start`);
  ({ ...b, ...c });
  performance.mark(`spread:${i}:stop`);
}

for (let i = 0; i < loops; i++) {
  Object.keys(times).forEach(name => performance.measure(name, `${name}:${i}:start`, `${name}:${i}:stop`));
}

Object.keys(times).forEach(name => {
  const durations = times[name];

  console.log(name, durations.reduce((sum, dur) => sum + dur, 0) / (durations.length + 1));
});

obs.disconnect();
```
</details>