### PR TITLE
fix: should throw `EEXIST` instead of `EISDIR` on `mkdirSync('/')`

### DIFF
--- a/src/__tests__/volume/__snapshots__/mkdirSync.test.ts.snap
+++ b/src/__tests__/volume/__snapshots__/mkdirSync.test.ts.snap
@@ -1,5 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`mkdirSync throws when creating root directory 1`] = `"EISDIR: illegal operation on a directory, mkdir '/'"`;
+exports[`mkdirSync throws when creating root directory 1`] = `"EEXIST: file already exists, mkdir '/'"`;
 
 exports[`mkdirSync throws when re-creating existing directory 1`] = `"EEXIST: file already exists, mkdir '/new-dir'"`;

--- a/src/volume.ts
+++ b/src/volume.ts
@@ -1812,7 +1812,7 @@ export class Volume {
 
     // This will throw if user tries to create root dir `fs.mkdirSync('/')`.
     if (!steps.length) {
-      throw createError(EISDIR, 'mkdir', filename);
+      throw createError(EEXIST, 'mkdir', filename);
     }
 
     const dir = this.getLinkParentAsDirOrThrow(filename, 'mkdir');


### PR DESCRIPTION
The `EISDIR` implementation is considered a bug in BSD operating
systems.

See the bug report at https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=59739
and the POSIX specification at https://pubs.opengroup.org/onlinepubs/9699919799/functions/mkdir.html