### PR TITLE
feat: add support for nested objects to `fromJSON()`

### DIFF
--- a/src/__tests__/volume.test.ts
+++ b/src/__tests__/volume.test.ts
@@ -197,16 +197,18 @@ describe('volume', () => {
         expect(vol.toJSON()).toEqual(json);
       });
 
-      it('Files at root with relative paths', () => {
+      it('Files and directories at root with relative paths', () => {
         const vol = new Volume();
         const json = {
           hello: 'world',
           'app.js': 'console.log(123)',
+          dir: {},
         };
         vol.fromJSON(json, '/');
         expect(vol.toJSON()).toEqual({
           '/hello': 'world',
           '/app.js': 'console.log(123)',
+          '/dir': null,
         });
       });
 

--- a/src/__tests__/volume.test.ts
+++ b/src/__tests__/volume.test.ts
@@ -222,6 +222,35 @@ describe('volume', () => {
         expect(vol.toJSON()).toEqual(json);
       });
 
+      it('Accept a nested dict as input because its nicer to read', () => {
+        const vol1 = new Volume();
+        const vol2 = new Volume();
+
+        const jsonFlat = {
+          '/dir/file': '...',
+          '/dir/dir/dir2/hello.sh': 'world',
+          '/hello.js': 'console.log(123)',
+          '/dir/dir/test.txt': 'Windows',
+        };
+        const jsonNested = {
+          '/dir/': {
+            file: '...',
+            dir: {
+              dir2: {
+                'hello.sh': 'world',
+              },
+              'test.txt': 'Windows',
+            },
+          },
+          '/hello.js': 'console.log(123)',
+        };
+
+        vol1.fromJSON(jsonFlat);
+        vol2.fromJSON(jsonNested);
+
+        expect(vol1.toJSON()).toEqual(vol2.toJSON());
+      });
+
       it('Invalid JSON throws error', () => {
         try {
           const vol = new Volume();

--- a/src/__tests__/volume.test.ts
+++ b/src/__tests__/volume.test.ts
@@ -202,7 +202,7 @@ describe('volume', () => {
         const json = {
           hello: 'world',
           'app.js': 'console.log(123)',
-          dir: {},
+          dir: null,
         };
         vol.fromJSON(json, '/');
         expect(vol.toJSON()).toEqual({
@@ -222,35 +222,6 @@ describe('volume', () => {
         };
         vol.fromJSON(json);
         expect(vol.toJSON()).toEqual(json);
-      });
-
-      it('Accept a nested dict as input because its nicer to read', () => {
-        const vol1 = new Volume();
-        const vol2 = new Volume();
-
-        const jsonFlat = {
-          '/dir/file': '...',
-          '/dir/dir/dir2/hello.sh': 'world',
-          '/hello.js': 'console.log(123)',
-          '/dir/dir/test.txt': 'Windows',
-        };
-        const jsonNested = {
-          '/dir/': {
-            file: '...',
-            dir: {
-              dir2: {
-                'hello.sh': 'world',
-              },
-              'test.txt': 'Windows',
-            },
-          },
-          '/hello.js': 'console.log(123)',
-        };
-
-        vol1.fromJSON(jsonFlat);
-        vol2.fromJSON(jsonNested);
-
-        expect(vol1.toJSON()).toEqual(vol2.toJSON());
       });
 
       it('Invalid JSON throws error', () => {
@@ -283,7 +254,7 @@ describe('volume', () => {
         }
       });
 
-      it('creates a folder if values is not a string', () => {
+      it('creates a folder if value is not a string', () => {
         const vol = Volume.fromJSON({
           '/dir': null,
         });
@@ -291,6 +262,46 @@ describe('volume', () => {
 
         expect(stat.isDirectory()).toBe(true);
         expect(vol.readdirSync('/dir')).toEqual([]);
+      });
+    });
+
+    describe('.fromNestedJSON(nestedJSON[, cwd]', () => {
+      it('Accept a nested dict as input because its nicer to read', () => {
+        const vol1 = new Volume();
+        const vol2 = new Volume();
+
+        const jsonFlat = {
+          '/dir/file': '...',
+          '/emptyDir': null,
+          '/anotherEmptyDir': null,
+          '/oneMoreEmptyDir': null,
+          '/dir/dir/dir2/hello.sh': 'world',
+          '/hello.js': 'console.log(123)',
+          '/dir/dir/test.txt': 'File with leading slash',
+        };
+        const jsonNested = {
+          '/dir/': {
+            file: '...',
+            dir: {
+              dir2: {
+                'hello.sh': 'world',
+              },
+              '/test.txt': 'File with leading slash',
+            },
+          },
+          '/emptyDir': {},
+          '/anotherEmptyDir': null,
+          '/oneMoreEmptyDir': {
+            '': null, // this could be considered a glitch, but "" is not a valid filename anyway
+            // (same as 'file/name' is invalid and would lead to problems)
+          },
+          '/hello.js': 'console.log(123)',
+        };
+
+        vol1.fromJSON(jsonFlat);
+        vol2.fromNestedJSON(jsonNested);
+
+        expect(vol1.toJSON()).toEqual(vol2.toJSON());
       });
     });
 

--- a/src/__tests__/volume.test.ts
+++ b/src/__tests__/volume.test.ts
@@ -265,7 +265,7 @@ describe('volume', () => {
       });
     });
 
-    describe('.fromNestedJSON(nestedJSON[, cwd]', () => {
+    describe('.fromNestedJSON(nestedJSON[, cwd])', () => {
       it('Accept a nested dict as input because its nicer to read', () => {
         const vol1 = new Volume();
         const vol2 = new Volume();

--- a/src/volume.ts
+++ b/src/volume.ts
@@ -502,15 +502,11 @@ export interface DirectoryJSON {
   [key: string]: string | null;
 }
 export interface NestedDirectoryJSON {
-  [key: string]: string | NestedDirectoryJSON | null;
+  [key: string]: string | null | NestedDirectoryJSON;
 }
 
 function flattenJSON(nestedJSON: NestedDirectoryJSON): DirectoryJSON {
   const flatJSON: DirectoryJSON = {};
-
-  flatten('', nestedJSON);
-
-  return flatJSON;
 
   function flatten(pathPrefix: string, node: NestedDirectoryJSON) {
     for (const path in node) {
@@ -531,6 +527,10 @@ function flattenJSON(nestedJSON: NestedDirectoryJSON): DirectoryJSON {
       }
     }
   }
+
+  flatten('', nestedJSON);
+
+  return flatJSON;
 }
 
 /**
@@ -544,7 +544,9 @@ export class Volume {
   }
 
   static fromNestedJSON(json: NestedDirectoryJSON, cwd?: string): Volume {
-    return Volume.fromJSON(flattenJSON(json), cwd);
+    const vol = new Volume();
+    vol.fromNestedJSON(json, cwd);
+    return vol;
   }
 
   /**

--- a/src/volume.ts
+++ b/src/volume.ts
@@ -872,8 +872,9 @@ export class Volume {
     for (let filename in json) {
       const data = json[filename];
 
+      filename = resolve(filename, cwd);
+
       if (typeof data === 'string') {
-        filename = resolve(filename, cwd);
         const steps = filenameToSteps(filename);
         if (steps.length > 1) {
           const dirname = sep + steps.slice(0, steps.length - 1).join(sep);

--- a/src/volume.ts
+++ b/src/volume.ts
@@ -497,12 +497,13 @@ function validateGid(gid: number) {
 }
 
 // ---------------------------------------- Volume
+type DirectoryContent = string | null;
 
 export interface DirectoryJSON {
-  [key: string]: string | null;
+  [key: string]: DirectoryContent;
 }
 export interface NestedDirectoryJSON {
-  [key: string]: string | null | NestedDirectoryJSON;
+  [key: string]: DirectoryContent | NestedDirectoryJSON;
 }
 
 function flattenJSON(nestedJSON: NestedDirectoryJSON): DirectoryJSON {


### PR DESCRIPTION
This adds support for nested object (literals) to `fromJSON()`. It reads much nicer and makes tests look cleaner (at least that is my personal opinion). One of the features I miss most not being able to use `mock-fs`.

I added this functionality to `fromJSON()` itself, one could argue having an additional method like `fromNestedJSON()` might be better regarding to backward compatibility. I don't think this is a problem at all, but the rather exotic corner case of calling `fromJSON()` with something like `{'dir1': {'dir2'}}` just created `dir1` so far, but would also create `dir2` from now on...

Feedback on this is highly appreciated!

Additionally this fixes a bug (at least I think it's one): so far `fromJSON()` only took the `cwd` parameter into account when creating files, not when creating directories.