### PR TITLE
Export Volume as a class instead of const

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,26 +1,18 @@
 import Stats from './Stats';
 import Dirent from './Dirent';
-import {
-  Volume as _Volume,
-  StatWatcher,
-  FSWatcher,
-  toUnixTimestamp,
-  IReadStream,
-  IWriteStream,
-  DirectoryJSON,
-} from './volume';
+import { Volume, StatWatcher, FSWatcher, toUnixTimestamp, IReadStream, IWriteStream, DirectoryJSON } from './volume';
 import { IPromisesAPI } from './promises';
 const { fsSyncMethods, fsAsyncMethods } = require('fs-monkey/lib/util/lists');
 import { constants } from './constants';
 const { F_OK, R_OK, W_OK, X_OK } = constants;
 
 export { DirectoryJSON };
-export const Volume = _Volume;
+export { Volume };
 
 // Default volume.
-export const vol = new _Volume();
+export const vol = new Volume();
 
-export interface IFs extends _Volume {
+export interface IFs extends Volume {
   constants: typeof constants;
   Stats: new (...args) => Stats;
   Dirent: new (...args) => Dirent;
@@ -32,7 +24,7 @@ export interface IFs extends _Volume {
   _toUnixTimestamp;
 }
 
-export function createFsFromVolume(vol: _Volume): IFs {
+export function createFsFromVolume(vol: Volume): IFs {
   const fs = ({ F_OK, R_OK, W_OK, X_OK, constants, Stats, Dirent } as any) as IFs;
 
   // Bind FS methods.


### PR DESCRIPTION
I ran into a TS error with the following code:

```ts
import { Volume } from 'memfs'

const vol = Volume.fromJSON({}) // works

const getData = (someVol: Volume) => {} // doesn't work
                          ~~~~~~
```
```
'Volume' refers to a value, but is being used as a type here. Did you mean 'typeof Volume'?
```

Using the suggested `typeof` doesn't help either:

```ts
const getData = (someVol: typeof Volume) => {} // works

getData(vol) // doesn't work
        ~~~
```

```
Argument of type 'Volume' is not assignable to parameter of type 'typeof Volume'.
  Type 'Volume' is missing the following properties from type 'typeof Volume': prototype, fd
```

The strange thing is that `Volume` is already exported as `typeof Volume`. However, it seems incorrect because in TS

>  a class declaration creates two things: a type representing instances of the class and a constructor function

as suggested in the [Handbook](https://www.typescriptlang.org/docs/handbook/classes.html#using-a-class-as-an-interface). Indeed, if I import the class directly, the error goes away:

```ts
import { Volume } from "memfs/lib/volume";
```

Any thoughts? Thanks.
