### PR TITLE
fix: add `The Unlicense` license SDPX in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
       "@semantic-release/git"
     ]
   },
+  "license": "Unlicense",
   "keywords": [
     "fs",
     "filesystem",


### PR DESCRIPTION
This is required by our ifra tooling to validate the license and allows us to consumed this package.

Fixes #658