### PR TITLE
fix: prevent callback from triggering twice when callback throws

### DIFF
--- a/src/__tests__/volume/callback-error.test.ts
+++ b/src/__tests__/volume/callback-error.test.ts
@@ -1,0 +1,15 @@
+jest.useFakeTimers('modern');
+
+// Fixes https://github.com/streamich/memfs/issues/542
+it('should throw error instead of callback', () => {
+  const { Volume } = require('../../volume');
+  const vol = new Volume();
+
+  vol.writeFile('/asdf.txt', 'asdf', 'utf8', (err) => {
+    if (!err) {
+      throw new Error('try to trigger catch');
+    }
+  });
+
+  expect(() => jest.runAllTimers()).toThrow('try to trigger catch');
+});

--- a/src/volume.ts
+++ b/src/volume.ts
@@ -826,11 +826,14 @@ export class Volume {
   private wrapAsync(method: (...args) => void, args: any[], callback: TCallback<any>) {
     validateCallback(callback);
     setImmediate(() => {
+      let result;
       try {
-        callback(null, method.apply(this, args));
+        result = method.apply(this, args);
       } catch (err) {
         callback(err);
+        return;
       }
+      callback(null, result);
     });
   }
 


### PR DESCRIPTION
closes #542