### PR TITLE
fix: global and timers this arg in browser

### DIFF
--- a/src/internal/errors.ts
+++ b/src/internal/errors.ts
@@ -21,7 +21,7 @@ function makeNodeError(Base) {
   };
 }
 
-class AssertionError extends global.Error {
+class AssertionError extends globalThis.Error {
   generatedMessage: any;
   name: any;
   code: any;
@@ -74,9 +74,9 @@ function E(sym, val) {
   messages[sym] = typeof val === 'function' ? val : String(val);
 }
 
-export const Error = makeNodeError(global.Error);
-export const TypeError = makeNodeError(global.TypeError);
-export const RangeError = makeNodeError(global.RangeError);
+export const Error = makeNodeError(globalThis.Error);
+export const TypeError = makeNodeError(globalThis.TypeError);
+export const RangeError = makeNodeError(globalThis.RangeError);
 
 export {
   message,

--- a/src/setImmediate.ts
+++ b/src/setImmediate.ts
@@ -1,7 +1,7 @@
 type TSetImmediate = (callback: (...args) => void, args?) => void;
 let _setImmediate: TSetImmediate;
 
-if (typeof setImmediate === 'function') _setImmediate = setImmediate.bind(global);
-else _setImmediate = setTimeout.bind(global);
+if (typeof setImmediate === 'function') _setImmediate = setImmediate.bind(globalThis);
+else _setImmediate = setTimeout.bind(globalThis);
 
 export default _setImmediate as TSetImmediate;

--- a/src/setTimeoutUnref.ts
+++ b/src/setTimeoutUnref.ts
@@ -5,7 +5,7 @@ export type TSetTimeout = (callback: (...args) => void, time?: number, args?: an
  * only in Node's environment it will "unref" its macro task.
  */
 function setTimeoutUnref(callback, time?, args?): object {
-  const ref = setTimeout.apply(null, arguments);
+  const ref = setTimeout.apply(globalThis, arguments);
   if (ref && typeof ref === 'object' && typeof ref.unref === 'function') ref.unref();
   return ref;
 }

--- a/src/volume.ts
+++ b/src/volume.ts
@@ -2220,7 +2220,7 @@ export class StatWatcher extends EventEmitter {
 
   start(path: string, persistent: boolean = true, interval: number = 5007) {
     this.filename = pathToFilename(path);
-    this.setTimeout = persistent ? setTimeout : setTimeoutUnref;
+    this.setTimeout = persistent ? setTimeout.bind(globalThis) : setTimeoutUnref;
     this.interval = interval;
     this.prev = this.vol.statSync(this.filename);
     this.loop();


### PR DESCRIPTION
This fixes for example `Uncaught TypeError: 'setTimeout' called on an object that does not implement interface Window.` on Firefox.