### PR TITLE
fix: recursively sync children steps to fix rename

### DIFF
--- a/src/__tests__/volume/renameSync.test.ts
+++ b/src/__tests__/volume/renameSync.test.ts
@@ -9,6 +9,30 @@ describe('renameSync(fromPath, toPath)', () => {
     expect(tryGetChildNode(vol.root, 'baz').isFile()).toBe(true);
     expect(vol.readFileSync('/baz', 'utf8')).toBe('bar');
   });
+  it('Updates deep links properly when renaming a directory', () => {
+    const vol = create({});
+    vol.mkdirpSync('/foo/bar/qux');
+    vol.writeFileSync('/foo/bar/qux/a.txt', 'hello');
+    vol.renameSync('/foo/', '/faa/');
+    expect(vol.toJSON()).toEqual({
+      '/faa/bar/qux/a.txt': 'hello',
+    });
+
+    vol.renameSync('/faa/bar/qux/a.txt', '/faa/bar/qux/b.txt');
+    expect(vol.toJSON()).toEqual({
+      '/faa/bar/qux/b.txt': 'hello',
+    });
+
+    vol.renameSync('/faa/', '/fuu/');
+    expect(vol.toJSON()).toEqual({
+      '/fuu/bar/qux/b.txt': 'hello',
+    });
+
+    vol.renameSync('/fuu/bar/', '/fuu/bur/');
+    expect(vol.toJSON()).toEqual({
+      '/fuu/bur/qux/b.txt': 'hello',
+    });
+  });
   it('Rename file two levels deep', () => {
     const vol = create({ '/1/2': 'foobar' });
     vol.renameSync('/1/2', '/1/3');

--- a/src/node.ts
+++ b/src/node.ts
@@ -239,7 +239,7 @@ export class Link extends EventEmitter {
   children: { [child: string]: Link | undefined } = {};
 
   // Path to this node as Array: ['usr', 'bin', 'node'].
-  steps: string[] = [];
+  private _steps: string[] = [];
 
   // "i-node" of this hard link.
   node: Node;
@@ -250,11 +250,26 @@ export class Link extends EventEmitter {
   // Number of children.
   length: number = 0;
 
+  name: string;
+
+  get steps() {
+    return this._steps;
+  }
+
+  // Recursively sync children steps, e.g. in case of dir rename
+  set steps(val) {
+    this._steps = val;
+    for (const child of Object.values(this.children)) {
+      child?.syncSteps()
+    }
+  }
+
   constructor(vol: Volume, parent: Link, name: string) {
     super();
     this.vol = vol;
     this.parent = parent;
-    this.steps = parent ? parent.steps.concat([name]) : [name];
+    this.name = name;
+    this.syncSteps();
   }
 
   setNode(node: Node) {
@@ -346,6 +361,10 @@ export class Link extends EventEmitter {
       ino: this.ino,
       children: Object.keys(this.children),
     };
+  }
+
+  syncSteps() {
+    this.steps = this.parent ? this.parent.steps.concat([this.name]) : [this.name];
   }
 }
 

--- a/src/volume.ts
+++ b/src/volume.ts
@@ -1626,6 +1626,7 @@ export class Volume {
 
     // Rename should overwrite the new path, if that exists.
     const name = newPathSteps[newPathSteps.length - 1];
+    link.name = name;
     link.steps = [...newPathDirLink.steps, name];
     newPathDirLink.setChild(link.getName(), link);
   }


### PR DESCRIPTION
fixes https://github.com/streamich/memfs/issues/397

I'm not familiar with the repo, just diving into it just now so forgive me if this approach is not what you guys had in mind. I didn't really see a trivial way around it other than creating a setter and recursively syncing children to parent.

When "steps" prop is set to a new value (e.g. in `renameBase`), it also goes through our children and sets their steps to synchronize with their parent which has changed.