### PR TITLE
Fix "Cannot set property closed of" on Node 18

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 refs:
   container: &container
     docker:
-      - image: node:14
+      - image: node:18
     working_directory: ~/repo
   steps:
     - &Versions

--- a/src/volume.ts
+++ b/src/volume.ts
@@ -2470,7 +2470,14 @@ FsReadStream.prototype.close = function(cb) {
     return process.nextTick(() => this.emit('close'));
   }
 
-  this.closed = true;
+  // Since Node 18, there is only a getter for '.closed'.
+  // The first branch mimics other setters from Readable.
+  // See https://github.com/nodejs/node/blob/v18.0.0/lib/internal/streams/readable.js#L1243
+  if (this._readableState && typeof this._readableState.closed === 'boolean') {
+    this._readableState.closed = true;
+  } else {
+    this.closed = true;
+  }
 
   this._vol.close(this.fd, er => {
     if (er) this.emit('error', er);

--- a/src/volume.ts
+++ b/src/volume.ts
@@ -2473,7 +2473,7 @@ FsReadStream.prototype.close = function(cb) {
   // Since Node 18, there is only a getter for '.closed'.
   // The first branch mimics other setters from Readable.
   // See https://github.com/nodejs/node/blob/v18.0.0/lib/internal/streams/readable.js#L1243
-  if (this._readableState && typeof this._readableState.closed === 'boolean') {
+  if (typeof this._readableState?.closed === 'boolean') {
     this._readableState.closed = true;
   } else {
     this.closed = true;
@@ -2622,8 +2622,35 @@ FsWriteStream.prototype._writev = function(data, cb) {
   if (this.pos !== undefined) this.pos += size;
 };
 
+FsWriteStream.prototype.close = function(cb) {
+  if (cb) this.once('close', cb);
+
+  if (this.closed || typeof this.fd !== 'number') {
+    if (typeof this.fd !== 'number') {
+      this.once('open', closeOnOpen);
+      return;
+    }
+    return process.nextTick(() => this.emit('close'));
+  }
+
+  // Since Node 18, there is only a getter for '.closed'.
+  // The first branch mimics other setters from Writable.
+  // See https://github.com/nodejs/node/blob/v18.0.0/lib/internal/streams/writable.js#L766
+  if (typeof this._writableState?.closed === 'boolean') {
+    this._writableState.closed = true;
+  } else {
+    this.closed = true;
+  }
+
+  this._vol.close(this.fd, er => {
+    if (er) this.emit('error', er);
+    else this.emit('close');
+  });
+
+  this.fd = null;
+};
+
 FsWriteStream.prototype._destroy = FsReadStream.prototype._destroy;
-FsWriteStream.prototype.close = FsReadStream.prototype.close;
 
 // There is no shutdown() for files.
 FsWriteStream.prototype.destroySoon = FsWriteStream.prototype.end;


### PR DESCRIPTION
Fixes https://github.com/streamich/memfs/issues/828

I'm not an expert on Node internals but from briefly reading the source code, it seems the problem is that `.closed` doesn't have a setter since Node 18 (https://github.com/nodejs/node/blob/v18.0.0/lib/internal/streams/readable.js#L1243). 

The fix is to check whether `this._readableState.closed` / `this._writableState.closed` exists and use it instead of `this.closed`. This mimics other setters from the `Readable`/`Writable` class.

I also upgraded the node image in CI - to use Node 18.

The test plan is I guess just to see if CI checks pass. I saw https://github.com/streamich/memfs/pull/829 and it seems the tests failed there. From my understanding, if my fix is correct, CI checks should pass now. I also ran `yarn test` locally on Node 18.1 and it succeeded.
