### PR TITLE
fix: allow `Uint8Array`s to be passed to `FsWriteStream`

### DIFF
--- a/src/volume.ts
+++ b/src/volume.ts
@@ -2567,7 +2567,7 @@ FsWriteStream.prototype.open = function() {
 };
 
 FsWriteStream.prototype._write = function(data, encoding, cb) {
-  if (!(data instanceof Buffer)) return this.emit('error', new Error('Invalid data'));
+  if (!(data instanceof Buffer || data instanceof Uint8Array)) return this.emit('error', new Error('Invalid data'));
 
   if (typeof this.fd !== 'number') {
     return this.once('open', function() {


### PR DESCRIPTION
From the Volume write function declaration, we can see the second argument has a type of Buffer or Uint8Array.
https://github.com/streamich/memfs/blob/05877386a95dab801621079ced2e09a45711e4d0/src/volume.ts#L1211-L1218
However, FsWriteStream.prototype._write only allows a type of Buffer:
https://github.com/streamich/memfs/blob/05877386a95dab801621079ced2e09a45711e4d0/src/volume.ts#L2569-L2591
This issue does cause an error of the combination: webpack 5 + node-downloader-helper + memfs.
node-downloader-helper and its dependencies can call FsWriteStream.prototype._write with a data of type Uint8Array.
(If anyone has an interest for an example, please try my project https://github.com/MrMYHuang/taa with memfs 3.4.3.)

After applying my changes, this issues is fixed.