### PR TITLE
test: remove redundant case

### DIFF
--- a/src/__tests__/process.test.ts
+++ b/src/__tests__/process.test.ts
@@ -6,10 +6,6 @@ describe('process', () => {
     it('Exports default object', () => {
       expect(typeof _process).toBe('object');
     });
-    it('.getuid() and .getgid()', () => {
-      expect(typeof proc.getuid?.() ?? 0).toBe('number');
-      expect(typeof proc.getgid?.() ?? 0).toBe('number');
-    });
     it('.cwd()', () => {
       expect(typeof proc.cwd()).toBe('string');
     });


### PR DESCRIPTION
This is now redundant because it's not actually testing anything useful - either the methods will be defined, which in case we're testing node internals, or they won't and we're testing the JS engines ability to implement syntax.