### PR TITLE
fix: support calling `utimes` on a directory

### DIFF
--- a/src/__tests__/volume.test.ts
+++ b/src/__tests__/volume.test.ts
@@ -961,10 +961,17 @@ describe('volume', () => {
     });
     describe('.utimesSync(path, atime, mtime)', () => {
       const vol = new Volume();
+      vol.mkdirSync('/foo');
       it('Set times on file', () => {
-        vol.writeFileSync('/lol', '12345');
-        vol.utimesSync('/lol', 1234, 12345);
-        const stats = vol.statSync('/lol');
+        vol.writeFileSync('/foo/lol', '12345');
+        vol.utimesSync('/foo/lol', 1234, 12345);
+        const stats = vol.statSync('/foo/lol');
+        expect(Math.round(stats.atime.getTime() / 1000)).toBe(1234);
+        expect(Math.round(stats.mtime.getTime() / 1000)).toBe(12345);
+      });
+      it("Sets times on a directory (see https://github.com/streamich/memfs/issues/391)", () => {
+        vol.utimesSync('/foo', 1234, 12345);
+        const stats = vol.statSync('/foo');
         expect(Math.round(stats.atime.getTime() / 1000)).toBe(1234);
         expect(Math.round(stats.mtime.getTime() / 1000)).toBe(12345);
       });

--- a/src/__tests__/volume.test.ts
+++ b/src/__tests__/volume.test.ts
@@ -976,7 +976,7 @@ describe('volume', () => {
         expect(Math.round(stats.atime.getTime() / 1000)).toBe(1234);
         expect(Math.round(stats.mtime.getTime() / 1000)).toBe(12345);
       });
-      it('Sets times on a directory (see https://github.com/streamich/memfs/issues/391)', () => {
+      it('Sets times on a directory', () => {
         vol.utimesSync('/foo', 1234, 12345);
         const stats = vol.statSync('/foo');
         expect(Math.round(stats.atime.getTime() / 1000)).toBe(1234);

--- a/src/__tests__/volume.test.ts
+++ b/src/__tests__/volume.test.ts
@@ -969,7 +969,7 @@ describe('volume', () => {
         expect(Math.round(stats.atime.getTime() / 1000)).toBe(1234);
         expect(Math.round(stats.mtime.getTime() / 1000)).toBe(12345);
       });
-      it("Sets times on a directory (see https://github.com/streamich/memfs/issues/391)", () => {
+      it('Sets times on a directory (see https://github.com/streamich/memfs/issues/391)', () => {
         vol.utimesSync('/foo', 1234, 12345);
         const stats = vol.statSync('/foo');
         expect(Math.round(stats.atime.getTime() / 1000)).toBe(1234);

--- a/src/volume.ts
+++ b/src/volume.ts
@@ -1881,7 +1881,7 @@ export class Volume {
   }
 
   private utimesBase(filename: string, atime: number, mtime: number) {
-    const fd = this.openSync(filename, 'r+');
+    const fd = this.openSync(filename, 'r');
     try {
       this.futimesBase(fd, atime, mtime);
     } finally {


### PR DESCRIPTION
- "EISDIR: illegal operation on a directory, open ..." error
- https://github.com/streamich/memfs/issues/391

Resolves #391