### PR TITLE
feat(volume): extended `vol.toJSON` with the `asBuffer` parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,11 +37,13 @@ const json = {
   './README.md': '1',
   './src/index.js': '2',
   './node_modules/debug/index.js': '3',
+  './src/index.node': Buffer.from('4', 'utf-8'),
 };
 vol.fromJSON(json, '/app');
 
 fs.readFileSync('/app/README.md', 'utf8'); // 1
 vol.readFileSync('/app/src/index.js', 'utf8'); // 2
+vol.readFileSync('/app/src/index.node', 'utf8'); // 4
 ```
 
 Export to JSON:

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -67,6 +67,7 @@ vol.fromJSON(
   {
     './index.js': '...',
     './package.json': '...',
+    './index.node': new Buffer(),
   },
   '/app',
 );

--- a/src/__tests__/volume.test.ts
+++ b/src/__tests__/volume.test.ts
@@ -263,6 +263,16 @@ describe('volume', () => {
         expect(stat.isDirectory()).toBe(true);
         expect(vol.readdirSync('/dir')).toEqual([]);
       });
+
+      it('supports using buffers for file content', () => {
+        const vol = new Volume();
+        const text = 'bip-boup';
+        const buffer = Buffer.from(text, 'utf-8');
+        vol.fromJSON({ '/buffer': buffer });
+        expect(vol.toJSON()).toStrictEqual({ '/buffer': text });
+        expect(vol.readFileSync('/buffer')).toStrictEqual(buffer);
+        expect(vol.readFileSync('/buffer', 'utf-8')).toStrictEqual(text);
+      });
     });
 
     describe('.fromNestedJSON(nestedJSON[, cwd])', () => {

--- a/src/__tests__/volume.test.ts
+++ b/src/__tests__/volume.test.ts
@@ -184,6 +184,14 @@ describe('volume', () => {
           '/empty': null,
         });
       });
+
+      it('Outputs files as buffers if the option is set', () => {
+        const buffer = Buffer.from('Hello');
+        const vol = new Volume();
+        vol.writeFileSync('/file', buffer);
+        const result = vol.toJSON('/', {}, false, true)['/file'];
+        expect(result).toStrictEqual(buffer);
+      });
     });
 
     describe('.fromJSON(json[, cwd])', () => {

--- a/src/volume.ts
+++ b/src/volume.ts
@@ -868,7 +868,7 @@ export class Volume {
     });
   }
 
-  private _toJSON(link = this.root, json = {}, path?: string): DirectoryJSON<string | null> {
+  private _toJSON(link = this.root, json = {}, path?: string, asBuffer?: boolean): DirectoryJSON<string | null> {
     let isEmpty = true;
 
     let children = link.children;
@@ -890,7 +890,7 @@ export class Volume {
       if (node.isFile()) {
         let filename = child.getPath();
         if (path) filename = relative(path, filename);
-        json[filename] = node.getString();
+        json[filename] = asBuffer ? node.getBuffer() : node.getString();
       } else if (node.isDirectory()) {
         this._toJSON(child, json, path);
       }
@@ -907,7 +907,7 @@ export class Volume {
     return json;
   }
 
-  toJSON(paths?: PathLike | PathLike[], json = {}, isRelative = false): DirectoryJSON<string | null> {
+  toJSON(paths?: PathLike | PathLike[], json = {}, isRelative = false, asBuffer = false): DirectoryJSON<string | null> {
     const links: Link[] = [];
 
     if (paths) {
@@ -923,7 +923,7 @@ export class Volume {
     }
 
     if (!links.length) return json;
-    for (const link of links) this._toJSON(link, json, isRelative ? link.getPath() : '');
+    for (const link of links) this._toJSON(link, json, isRelative ? link.getPath() : '', asBuffer);
     return json;
   }
 

--- a/src/volume.ts
+++ b/src/volume.ts
@@ -523,13 +523,13 @@ function validateGid(gid: number) {
 }
 
 // ---------------------------------------- Volume
-type DirectoryContent = string | null;
+type DirectoryContent = string | Buffer | null;
 
-export interface DirectoryJSON {
-  [key: string]: DirectoryContent;
+export interface DirectoryJSON<T extends DirectoryContent = DirectoryContent> {
+  [key: string]: T;
 }
-export interface NestedDirectoryJSON {
-  [key: string]: DirectoryContent | NestedDirectoryJSON;
+export interface NestedDirectoryJSON<T extends DirectoryContent = DirectoryContent> {
+  [key: string]: T | NestedDirectoryJSON;
 }
 
 function flattenJSON(nestedJSON: NestedDirectoryJSON): DirectoryJSON {
@@ -541,7 +541,7 @@ function flattenJSON(nestedJSON: NestedDirectoryJSON): DirectoryJSON {
 
       const joinedPath = join(pathPrefix, path);
 
-      if (typeof contentOrNode === 'string') {
+      if (typeof contentOrNode === 'string' || contentOrNode instanceof Buffer) {
         flatJSON[joinedPath] = contentOrNode;
       } else if (typeof contentOrNode === 'object' && contentOrNode !== null && Object.keys(contentOrNode).length > 0) {
         // empty directories need an explicit entry and therefore get handled in `else`, non-empty ones are implicitly considered
@@ -868,7 +868,7 @@ export class Volume {
     });
   }
 
-  private _toJSON(link = this.root, json = {}, path?: string): DirectoryJSON {
+  private _toJSON(link = this.root, json = {}, path?: string): DirectoryJSON<string | null> {
     let isEmpty = true;
 
     let children = link.children;
@@ -907,7 +907,7 @@ export class Volume {
     return json;
   }
 
-  toJSON(paths?: PathLike | PathLike[], json = {}, isRelative = false): DirectoryJSON {
+  toJSON(paths?: PathLike | PathLike[], json = {}, isRelative = false): DirectoryJSON<string | null> {
     const links: Link[] = [];
 
     if (paths) {
@@ -933,7 +933,7 @@ export class Volume {
 
       filename = resolve(filename, cwd);
 
-      if (typeof data === 'string') {
+      if (typeof data === 'string' || data instanceof Buffer) {
         const dir = dirname(filename);
         this.mkdirpBase(dir, MODE.DIR);
 


### PR DESCRIPTION
![code.png](https://i.imgur.com/nyA4TDB.png)

## Context

Review feedback from the #880.
Note that this PR is isolated and does not include #880 

## Actions

Extended `vol.toJSON` so it can now output the virtual directory structure as a map of `Buffer` if the `asBuffer` parameter is set to `true`