### PR TITLE
fix: `mkdir` return value

### DIFF
--- a/src/__tests__/volume.test.ts
+++ b/src/__tests__/volume.test.ts
@@ -1008,7 +1008,7 @@ describe('volume', () => {
       });
       it('Create /dir1/dir2/dir3 recursively', () => {
         const vol = new Volume();
-        vol.mkdirSync('/dir1/dir2/dir3', { recursive: true });
+        const fullPath = vol.mkdirSync('/dir1/dir2/dir3', { recursive: true });
         const dir1 = tryGetChild(vol.root, 'dir1');
         const dir2 = tryGetChild(dir1, 'dir2');
         const dir3 = tryGetChild(dir2, 'dir3');
@@ -1018,6 +1018,9 @@ describe('volume', () => {
         expect(dir1.getNode().isDirectory()).toBe(true);
         expect(dir2.getNode().isDirectory()).toBe(true);
         expect(dir3.getNode().isDirectory()).toBe(true);
+        expect(fullPath).toBe('/dir1/dir2/dir3');
+        const dirAlreadyExists = vol.mkdirSync('/dir1/dir2/dir3', { recursive: true });
+        expect(dirAlreadyExists).toBe(undefined);
       });
     });
     describe('.mkdir(path[, mode], callback)', () => {

--- a/src/volume.ts
+++ b/src/volume.ts
@@ -433,7 +433,7 @@ if (isWin) {
 
 export function filenameToSteps(filename: string, base?: string): string[] {
   const fullPath = resolve(filename, base);
-  const fullPathSansSlash = fullPath.substr(1);
+  const fullPathSansSlash = fullPath.substring(1);
   if (!fullPathSansSlash) return [];
   return fullPathSansSlash.split(sep);
 }
@@ -728,7 +728,7 @@ export class Volume {
 
   // Generates 6 character long random string, used by `mkdtemp`.
   genRndStr() {
-    const str = (Math.random() + 1).toString(36).substr(2, 6);
+    const str = (Math.random() + 1).toString(36).substring(2, 8);
     if (str.length === 6) return str;
     else return this.genRndStr();
   }
@@ -1923,7 +1923,7 @@ export class Volume {
    */
   private mkdirpBase(filename: string, modeNum: number) {
     const fullPath = resolve(filename);
-    const fullPathSansSlash = fullPath.substr(1);
+    const fullPathSansSlash = fullPath.substring(1);
     const steps = !fullPathSansSlash ? [] : fullPathSansSlash.split(sep);
     let link = this.root;
     let created = false;

--- a/src/volume.ts
+++ b/src/volume.ts
@@ -1970,7 +1970,7 @@ export class Volume {
 
   // legacy interface
   mkdirpSync(path: PathLike, mode?: TMode) {
-    this.mkdirSync(path, { mode, recursive: true });
+    return this.mkdirSync(path, { mode, recursive: true });
   }
 
   mkdirp(path: PathLike, callback: TCallback<string>);


### PR DESCRIPTION
https://nodejs.org/dist/latest-v18.x/docs/api/fs.html#fsmkdirpath-options-callback

> The callback is given a possible exception and, if recursive is true, the first directory path created, (err[, path]). path can still be undefined when recursive is true, if no directory was created.

https://nodejs.org/dist/latest-v18.x/docs/api/fs.html#fsmkdirsyncpath-options

> Synchronously creates a directory. Returns undefined, or if recursive is true, the first directory path created.

Resolves #546