### PR TITLE
fix: bump fs-monkey minimum version for rm support

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     }
   },
   "dependencies": {
-    "fs-monkey": "^1.0.3"
+    "fs-monkey": "^1.0.4"
   },
   "devDependencies": {
     "@semantic-release/changelog": "^6.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2179,10 +2179,10 @@ fs-minipass@^2.0.0, fs-minipass@^2.1.0:
   dependencies:
     minipass "^3.0.0"
 
-fs-monkey@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/fs-monkey/-/fs-monkey-1.0.3.tgz#ae3ac92d53bb328efe0e9a1d9541f6ad8d48e2d3"
-  integrity sha512-cybjIfiiE+pTWicSCLFHSrXZ6EilF30oh91FDP9S2B051prEa7QWfrVTQm10/dDpswBDXZugPa1Ogu8Yh+HV0Q==
+fs-monkey@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/fs-monkey/-/fs-monkey-1.0.4.tgz#ee8c1b53d3fe8bb7e5d2c5c5dfc0168afdd2f747"
+  integrity sha512-INM/fWAxMICjttnD0DX1rBvinKskj5G1w+oy/pnm9u/tSlnBrzFonJMcalKJ30P8RRsPzKcCG7Q8l0jx5Fh9YQ==
 
 fs.realpath@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Version 1.0.4 supports `.rm` and `.rmSync`: https://github.com/streamich/fs-monkey/releases/tag/v1.0.4

Technically, the existing version specification allows this drift: https://github.com/streamich/memfs/blob/09eab278ec0deb82dd4576dea27a48930e4c0e9b/package.json#L78-L80

However, for completeness, we should use `^1.0.4` so `rm*` "just works".

Closes #884