### PR TITLE
ci: properly release prereleases

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,13 @@
     }
   },
   "release": {
+    "branches": [
+      "master",
+      {
+        "name": "next",
+        "prerelease": true
+      }
+    ],
     "prepare": [
       "@semantic-release/changelog",
       "@semantic-release/npm",


### PR DESCRIPTION
It looks like prereleases are being done using non-prerelease versions i.e. 4.0, 4.1 - this might mean those versions are effectively burned, though I swear npm allowed you to unpublish or override a version if it was marked as a pre-release but I can't find that in the docs.

Still, this configuration should fix that so going forward changes to `next` should result in `4.2.0-rc1` etc.

The best way to apply this would be to merge it into `master` and then rebase `next` on to `master` to avoid a conflict - @streamich this should be done before any more changes are landed into `next` to avoid publishing more versions.