### PR TITLE
Print tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ npm i memfs
 - `experimental` [File System Access API to `fs` adapter](./docs/fsa/fsa-to-fs.md)
 - `experimental` [`crudfs` a CRUD-like file system abstraction](./docs/crudfs/index.md)
 - `experimental` [`casfs` Content Addressable Storage file system abstraction](./docs/casfs/index.md)
+- [`print` directory tree to terminal](./docs/print/index.md)
 
 
 ## Demos

--- a/demo/git/index.ts
+++ b/demo/git/index.ts
@@ -4,7 +4,7 @@ import git from 'isomorphic-git';
 import {memfs} from '../../src';
 
 const main = async () => {
-  const fs = memfs();
+  const {fs} = memfs();
 
   fs.mkdirSync('/repo');
   console.log('New folder:', (<any>fs).__vol.toJSON());

--- a/demo/print/fs.ts
+++ b/demo/print/fs.ts
@@ -3,7 +3,7 @@
 import * as fs from 'fs';
 import {toTreeSync} from '../../src/print';
 
-console.log(toTreeSync(<any>fs, {dir: process.cwd() + '/src'}));
+console.log(toTreeSync(<any>fs, {dir: process.cwd() + '/src/fsa-to-node'}));
 
 // Output:
 // src/

--- a/demo/print/fs.ts
+++ b/demo/print/fs.ts
@@ -1,0 +1,163 @@
+// Run: npx ts-node demo/print/fs.ts
+
+import * as fs from 'fs';
+import {toTreeSync} from '../../src/print';
+
+console.log(toTreeSync(<any>fs, {dir: process.cwd() + '/src'}));
+
+// Output:
+// src/
+// ├─ Dirent.ts
+// ├─ Stats.ts
+// ├─ __tests__/
+// │  ├─ hasBigInt.js
+// │  ├─ index.test.ts
+// │  ├─ node.test.ts
+// │  ├─ process.test.ts
+// │  ├─ promises.test.ts
+// │  ├─ setImmediate.test.ts
+// │  ├─ setTimeoutUnref.test.ts
+// │  ├─ util.ts
+// │  ├─ volume/
+// │  │  ├─ ReadStream.test.ts
+// │  │  ├─ WriteStream.test.ts
+// │  │  ├─ __snapshots__/
+// │  │  │  ├─ mkdirSync.test.ts.snap
+// │  │  │  ├─ renameSync.test.ts.snap
+// │  │  │  └─ writeSync.test.ts.snap
+// │  │  ├─ appendFile.test.ts
+// │  │  ├─ appendFileSync.test.ts
+// │  │  ├─ closeSync.test.ts
+// │  │  ├─ copyFile.test.ts
+// │  │  ├─ copyFileSync.test.ts
+// │  │  ├─ exists.test.ts
+// │  │  ├─ existsSync.test.ts
+// │  │  ├─ mkdirSync.test.ts
+// │  │  ├─ openSync.test.ts
+// │  │  ├─ readFile.test.ts
+// │  │  ├─ readSync.test.ts
+// │  │  ├─ readdirSync.test.ts
+// │  │  ├─ realpathSync.test.ts
+// │  │  ├─ rename.test.ts
+// │  │  ├─ renameSync.test.ts
+// │  │  ├─ rmPromise.test.ts
+// │  │  ├─ rmSync.test.ts
+// │  │  ├─ statSync.test.ts
+// │  │  ├─ toString.test.ts
+// │  │  ├─ write.test.ts
+// │  │  ├─ writeFileSync.test.ts
+// │  │  └─ writeSync.test.ts
+// │  └─ volume.test.ts
+// ├─ cas/
+// │  ├─ README.md
+// │  └─ types.ts
+// ├─ constants.ts
+// ├─ consts/
+// │  ├─ AMODE.ts
+// │  └─ FLAG.ts
+// ├─ crud/
+// │  ├─ README.md
+// │  ├─ __tests__/
+// │  │  ├─ matryoshka.test.ts
+// │  │  └─ testCrudfs.ts
+// │  ├─ types.ts
+// │  └─ util.ts
+// ├─ crud-to-cas/
+// │  ├─ CrudCas.ts
+// │  ├─ __tests__/
+// │  │  ├─ CrudCas.test.ts
+// │  │  ├─ __snapshots__/
+// │  │  │  └─ CrudCas.test.ts.snap
+// │  │  └─ testCasfs.ts
+// │  ├─ index.ts
+// │  └─ util.ts
+// ├─ encoding.ts
+// ├─ fsa/
+// │  └─ types.ts
+// ├─ fsa-to-crud/
+// │  ├─ FsaCrud.ts
+// │  ├─ __tests__/
+// │  │  └─ FsaCrud.test.ts
+// │  ├─ index.ts
+// │  └─ util.ts
+// ├─ fsa-to-node/
+// │  ├─ FsaNodeCore.ts
+// │  ├─ FsaNodeDirent.ts
+// │  ├─ FsaNodeFs.ts
+// │  ├─ FsaNodeFsOpenFile.ts
+// │  ├─ FsaNodeReadStream.ts
+// │  ├─ FsaNodeStats.ts
+// │  ├─ FsaNodeWriteStream.ts
+// │  ├─ __tests__/
+// │  │  ├─ FsaNodeFs.test.ts
+// │  │  └─ util.test.ts
+// │  ├─ constants.ts
+// │  ├─ index.ts
+// │  ├─ json.ts
+// │  ├─ types.ts
+// │  ├─ util.ts
+// │  └─ worker/
+// │     ├─ FsaNodeSyncAdapterWorker.ts
+// │     ├─ FsaNodeSyncWorker.ts
+// │     ├─ SyncMessenger.ts
+// │     ├─ constants.ts
+// │     └─ types.ts
+// ├─ index.ts
+// ├─ internal/
+// │  ├─ buffer.ts
+// │  └─ errors.ts
+// ├─ node/
+// │  ├─ FileHandle.ts
+// │  ├─ FsPromises.ts
+// │  ├─ constants.ts
+// │  ├─ lists/
+// │  │  ├─ fsCallbackApiList.ts
+// │  │  ├─ fsCommonObjectsList.ts
+// │  │  └─ fsSynchronousApiList.ts
+// │  ├─ options.ts
+// │  ├─ types/
+// │  │  ├─ FsCallbackApi.ts
+// │  │  ├─ FsCommonObjects.ts
+// │  │  ├─ FsPromisesApi.ts
+// │  │  ├─ FsSynchronousApi.ts
+// │  │  ├─ index.ts
+// │  │  ├─ misc.ts
+// │  │  └─ options.ts
+// │  └─ util.ts
+// ├─ node-to-crud/
+// │  ├─ NodeCrud.ts
+// │  ├─ __tests__/
+// │  │  └─ FsaCrud.test.ts
+// │  └─ index.ts
+// ├─ node-to-fsa/
+// │  ├─ NodeFileSystemDirectoryHandle.ts
+// │  ├─ NodeFileSystemFileHandle.ts
+// │  ├─ NodeFileSystemHandle.ts
+// │  ├─ NodeFileSystemSyncAccessHandle.ts
+// │  ├─ NodeFileSystemWritableFileStream.ts
+// │  ├─ NodePermissionStatus.ts
+// │  ├─ README.md
+// │  ├─ __tests__/
+// │  │  ├─ NodeFileSystemDirectoryHandle.test.ts
+// │  │  ├─ NodeFileSystemFileHandle.test.ts
+// │  │  ├─ NodeFileSystemHandle.test.ts
+// │  │  ├─ NodeFileSystemSyncAccessHandle.test.ts
+// │  │  ├─ NodeFileSystemWritableFileStream.test.ts
+// │  │  ├─ scenarios.test.ts
+// │  │  └─ util.test.ts
+// │  ├─ index.ts
+// │  ├─ types.ts
+// │  └─ util.ts
+// ├─ node.ts
+// ├─ print/
+// │  ├─ __tests__/
+// │  │  └─ index.test.ts
+// │  └─ index.ts
+// ├─ process.ts
+// ├─ setImmediate.ts
+// ├─ setTimeoutUnref.ts
+// ├─ volume-localstorage.ts
+// ├─ volume.ts
+// └─ webfs/
+//    ├─ index.ts
+//    └─ webpack.config.js

--- a/demo/volume/print-tree.ts
+++ b/demo/volume/print-tree.ts
@@ -1,0 +1,37 @@
+// Run: npx ts-node demo/volume/print-tree.ts
+
+import { memfs } from '../../src';
+
+const { vol } = memfs({
+  '/Users/streamich/src/github/memfs/src': {
+    'package.json': '...',
+    'tsconfig.json': '...',
+    'index.ts': '...',
+    'util': {
+      'index.ts': '...',
+      'print': {
+        'index.ts': '...',
+        'printTree.ts': '...',
+      },
+    },
+  },
+});
+
+console.log(vol.toTree());
+
+// Output:
+// /
+// └─ Users/
+//    └─ streamich/
+//       └─ src/
+//          └─ github/
+//             └─ memfs/
+//                └─ src/
+//                   ├─ index.ts
+//                   ├─ package.json
+//                   ├─ tsconfig.json
+//                   └─ util/
+//                      ├─ index.ts
+//                      └─ print/
+//                         ├─ index.ts
+//                         └─ printTree.ts

--- a/docs/node/reference.md
+++ b/docs/node/reference.md
@@ -94,8 +94,6 @@ an array of paths. A path can be a string, `Buffer` or an `URL` object.
 
 `isRelative` is boolean that specifies if returned paths should be relative.
 
-**Note:** JSON contains only files, empty folders will be absent.
-
 
 #### `vol.reset()`
 
@@ -107,6 +105,52 @@ vol.toJSON(); // {'/index.js': '...' }
 vol.reset();
 vol.toJSON(); // {}
 ```
+
+
+#### `vol.toTree()`
+
+Returns a string representation of a volume folder contents as a tree.
+
+```ts
+import { memfs } from 'memfs';
+
+const { vol } = memfs({
+  '/Users/streamich/src/github/memfs/src': {
+    'package.json': '...',
+    'tsconfig.json': '...',
+    'index.ts': '...',
+    'util': {
+      'index.ts': '...',
+      'print': {
+        'index.ts': '...',
+        'printTree.ts': '...',
+      },
+    },
+  },
+});
+
+console.log(vol.toTree());
+
+// Output:
+// /
+// └─ Users/
+//    └─ streamich/
+//       └─ src/
+//          └─ github/
+//             └─ memfs/
+//                └─ src/
+//                   ├─ index.ts
+//                   ├─ package.json
+//                   ├─ tsconfig.json
+//                   └─ util/
+//                      ├─ index.ts
+//                      └─ print/
+//                         ├─ index.ts
+//                         └─ printTree.ts
+```
+
+The `.toTree()` method accepts options object, where one can specify a sub-folder,
+depth of the printed tree, and a separator.
 
 
 ## `createFsFromVolume(vol)`

--- a/docs/print/index.md
+++ b/docs/print/index.md
@@ -1,0 +1,50 @@
+# `print` utility
+
+The print utility allows on to print an ASCII tree of some file system directory.
+You pass in the file system object and the folder path, and it will print out the tree.
+
+Here is the [`/src` folder print demo of this project](../../demo/print/fs.ts):
+
+```ts
+import * as fs from 'fs';
+import {toTreeSync} from 'memfs/lib/print';
+
+console.log(toTreeSync(fs, {dir: process.cwd() + '/src/fsa-to-node'}));
+
+// Output:
+// src/
+// ├─ Dirent.ts
+// ├─ Stats.ts
+// ├─ __tests__/
+// │  ├─ hasBigInt.js
+// │  ├─ index.test.ts
+// │  ├─ node.test.ts
+// │  ├─ process.test.ts
+// │  ├─ promises.test.ts
+// ...
+```
+
+You can pass in any `fs` implementation, including the in-memory one from `memfs`.
+
+```ts
+import { memfs } from 'memfs';
+
+const { fs } = memfs({
+  '/Users/streamich/src/github/memfs/src': {
+    'package.json': '...',
+    'tsconfig.json': '...',
+  },
+});
+
+console.log(toTreeSync(fs));
+
+// /
+// └─ Users/
+//    └─ streamich/
+//       └─ src/
+//          └─ github/
+//             └─ memfs/
+//                └─ src/
+//                   ├─ package.json
+//                   ├─ tsconfig.json
+```

--- a/docs/print/index.md
+++ b/docs/print/index.md
@@ -1,6 +1,6 @@
 # `print` utility
 
-The print utility allows on to print an ASCII tree of some file system directory.
+The print utility allows one to print an ASCII tree of some file system directory.
 You pass in the file system object and the folder path, and it will print out the tree.
 
 Here is the [`/src` folder print demo of this project](../../demo/print/fs.ts):

--- a/src/__tests__/volume/readFile.test.ts
+++ b/src/__tests__/volume/readFile.test.ts
@@ -3,13 +3,13 @@ import { memfs } from '../..';
 
 describe('.readFile()', () => {
   it('can read a file', async () => {
-    const fs = memfs({ '/dir/test.txt': '01234567' });
+    const { fs } = memfs({ '/dir/test.txt': '01234567' });
     const data = await fs.promises.readFile('/dir/test.txt', { encoding: 'utf8' });
     expect(data).toBe('01234567');
   });
 
   it('throws if file does not exist', async () => {
-    const fs = memfs({ '/dir/test.txt': '01234567' });
+    const { fs } = memfs({ '/dir/test.txt': '01234567' });
     const [, err] = await of(fs.promises.readFile('/dir/test-NOT-FOUND.txt', { encoding: 'utf8' }));
     expect(err).toBeInstanceOf(Error);
     expect((<any>err).code).toBe('ENOENT');

--- a/src/__tests__/volume/writeSync.test.ts
+++ b/src/__tests__/volume/writeSync.test.ts
@@ -19,7 +19,7 @@ describe('.writeSync(fd, buffer, offset, length, position)', () => {
   });
 
   it('can write at offset', () => {
-    const fs = memfs({ foo: '123' });
+    const { fs } = memfs({ foo: '123' });
     const fd = fs.openSync('/foo', 'a+');
     expect(fs.readFileSync('/foo', 'utf8')).toBe('123');
     fs.writeSync(fd, 'x', 1);

--- a/src/crud-to-cas/__tests__/CrudCas.test.ts
+++ b/src/crud-to-cas/__tests__/CrudCas.test.ts
@@ -8,7 +8,7 @@ import { NodeCrud } from '../../node-to-crud/NodeCrud';
 
 onlyOnNode20('CrudCas on FsaCrud', () => {
   const setup = () => {
-    const fs = memfs();
+    const { fs } = memfs();
     const fsa = new NodeFileSystemDirectoryHandle(fs, '/', { mode: 'readwrite' });
     const crud = new FsaCrud(fsa);
     const cas = new CrudCas(crud, { hash });
@@ -19,7 +19,7 @@ onlyOnNode20('CrudCas on FsaCrud', () => {
 
 onlyOnNode20('CrudCas on NodeCrud at root', () => {
   const setup = () => {
-    const fs = memfs();
+    const { fs } = memfs();
     const crud = new NodeCrud({ fs: fs.promises, dir: '/' });
     const cas = new CrudCas(crud, { hash });
     return { fs, crud, cas, snapshot: () => (<any>fs).__vol.toJSON() };
@@ -29,7 +29,7 @@ onlyOnNode20('CrudCas on NodeCrud at root', () => {
 
 onlyOnNode20('CrudCas on NodeCrud at in sub-folder', () => {
   const setup = () => {
-    const fs = memfs({ '/a/b/c': null });
+    const { fs } = memfs({ '/a/b/c': null });
     const crud = new NodeCrud({ fs: fs.promises, dir: '/a/b/c' });
     const cas = new CrudCas(crud, { hash });
     return { fs, crud, cas, snapshot: () => (<any>fs).__vol.toJSON() };

--- a/src/crud/__tests__/matryoshka.test.ts
+++ b/src/crud/__tests__/matryoshka.test.ts
@@ -9,7 +9,7 @@ import { FsaCrud } from '../../fsa-to-crud';
 onlyOnNode20('CRUD matryoshka', () => {
   describe('crud(memfs)', () => {
     testCrudfs(() => {
-      const fs = memfs();
+      const { fs } = memfs();
       const crud = new NodeCrud({ fs: fs.promises, dir: '/' });
       return { crud, snapshot: () => (<any>fs).__vol.toJSON() };
     });
@@ -17,7 +17,7 @@ onlyOnNode20('CRUD matryoshka', () => {
 
   describe('crud(fsa(memfs))', () => {
     testCrudfs(() => {
-      const fs = memfs();
+      const { fs } = memfs();
       const fsa = new NodeFileSystemDirectoryHandle(fs, '/', { mode: 'readwrite' });
       const crud = new FsaCrud(fsa);
       return { crud, snapshot: () => (<any>fs).__vol.toJSON() };
@@ -26,7 +26,7 @@ onlyOnNode20('CRUD matryoshka', () => {
 
   describe('crud(fs(fsa(memfs)))', () => {
     testCrudfs(() => {
-      const fs = memfs();
+      const { fs } = memfs();
       const fsa = new NodeFileSystemDirectoryHandle(fs, '/', { mode: 'readwrite' });
       const fs2 = new FsaNodeFs(fsa);
       const crud = new NodeCrud({ fs: fs2.promises, dir: '/' });
@@ -36,7 +36,7 @@ onlyOnNode20('CRUD matryoshka', () => {
 
   describe('crud(fsa(fs(fsa(memfs))))', () => {
     testCrudfs(() => {
-      const fs = memfs();
+      const { fs } = memfs();
       const fsa = new NodeFileSystemDirectoryHandle(fs, '/', { mode: 'readwrite' });
       const fs2 = new FsaNodeFs(fsa);
       const fsa2 = new NodeFileSystemDirectoryHandle(fs2, '/', { mode: 'readwrite' });
@@ -47,7 +47,7 @@ onlyOnNode20('CRUD matryoshka', () => {
 
   describe('crud(fs(fsa(fs(fsa(memfs)))))', () => {
     testCrudfs(() => {
-      const fs = memfs();
+      const { fs } = memfs();
       const fsa = new NodeFileSystemDirectoryHandle(fs, '/', { mode: 'readwrite' });
       const fs2 = new FsaNodeFs(fsa);
       const fsa2 = new NodeFileSystemDirectoryHandle(fs2, '/', { mode: 'readwrite' });
@@ -59,7 +59,7 @@ onlyOnNode20('CRUD matryoshka', () => {
 
   describe('crud(fsa(fs(fsa(fs(fsa(memfs))))))', () => {
     testCrudfs(() => {
-      const fs = memfs();
+      const { fs } = memfs();
       const fsa = new NodeFileSystemDirectoryHandle(fs, '/', { mode: 'readwrite' });
       const fs2 = new FsaNodeFs(fsa);
       const fsa2 = new NodeFileSystemDirectoryHandle(fs2, '/', { mode: 'readwrite' });

--- a/src/fsa-to-crud/__tests__/FsaCrud.test.ts
+++ b/src/fsa-to-crud/__tests__/FsaCrud.test.ts
@@ -5,7 +5,7 @@ import { FsaCrud } from '../FsaCrud';
 import { testCrudfs } from '../../crud/__tests__/testCrudfs';
 
 const setup = () => {
-  const fs = memfs();
+  const { fs } = memfs();
   const fsa = new NodeFileSystemDirectoryHandle(fs, '/', { mode: 'readwrite' });
   const crud = new FsaCrud(fsa);
   return { fs, fsa, crud, snapshot: () => (<any>fs).__vol.toJSON() };

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,10 +65,10 @@ export const fs: IFs = createFsFromVolume(vol);
  * @returns A `memfs` file system instance, which is a drop-in replacement for
  *          the `fs` module.
  */
-export const memfs = (json: NestedDirectoryJSON = {}, cwd: string = '/'): IFs => {
-  const volume = Volume.fromNestedJSON(json, cwd);
-  const fs = createFsFromVolume(volume);
-  return fs;
+export const memfs = (json: NestedDirectoryJSON = {}, cwd: string = '/'): { fs: IFs; vol: _Volume } => {
+  const vol = Volume.fromNestedJSON(json, cwd);
+  const fs = createFsFromVolume(vol);
+  return { fs, vol };
 };
 
 export type IFsWithVolume = IFs & { __vol: _Volume };

--- a/src/node-to-crud/__tests__/FsaCrud.test.ts
+++ b/src/node-to-crud/__tests__/FsaCrud.test.ts
@@ -4,7 +4,7 @@ import { NodeCrud } from '../NodeCrud';
 import { testCrudfs } from '../../crud/__tests__/testCrudfs';
 
 const setup = () => {
-  const fs = memfs();
+  const { fs } = memfs();
   const crud = new NodeCrud({
     fs: fs.promises,
     dir: '/',

--- a/src/node-to-fsa/__tests__/NodeFileSystemDirectoryHandle.test.ts
+++ b/src/node-to-fsa/__tests__/NodeFileSystemDirectoryHandle.test.ts
@@ -5,7 +5,7 @@ import { NodeFileSystemHandle } from '../NodeFileSystemHandle';
 import { onlyOnNode20 } from '../../__tests__/util';
 
 const setup = (json: DirectoryJSON = {}) => {
-  const fs = memfs(json, '/');
+  const { fs } = memfs(json, '/');
   const dir = new NodeFileSystemDirectoryHandle(fs as any, '/', { mode: 'readwrite' });
   return { dir, fs };
 };
@@ -160,7 +160,7 @@ onlyOnNode20('NodeFileSystemDirectoryHandle', () => {
     });
 
     test('throws if not in "readwrite" mode and attempting to create a directory', async () => {
-      const fs = memfs({}, '/');
+      const { fs } = memfs({}, '/');
       const dir = new NodeFileSystemDirectoryHandle(fs as any, '/', { mode: 'read' });
       try {
         await dir.getDirectoryHandle('test', { create: true });
@@ -255,7 +255,7 @@ onlyOnNode20('NodeFileSystemDirectoryHandle', () => {
     });
 
     test('throws if not in "readwrite" mode and attempting to create a file', async () => {
-      const fs = memfs({}, '/');
+      const { fs } = memfs({}, '/');
       const dir = new NodeFileSystemDirectoryHandle(fs as any, '/', { mode: 'read' });
       try {
         await dir.getFileHandle('test', { create: true });
@@ -339,7 +339,7 @@ onlyOnNode20('NodeFileSystemDirectoryHandle', () => {
     });
 
     test('throws if not in "readwrite" mode and attempting to remove a file', async () => {
-      const fs = memfs({ a: 'b' }, '/');
+      const { fs } = memfs({ a: 'b' }, '/');
       const dir = new NodeFileSystemDirectoryHandle(fs as any, '/', { mode: 'read' });
       try {
         await dir.removeEntry('a');
@@ -354,7 +354,7 @@ onlyOnNode20('NodeFileSystemDirectoryHandle', () => {
     });
 
     test('throws if not in "readwrite" mode and attempting to remove a folder', async () => {
-      const fs = memfs({ a: null }, '/');
+      const { fs } = memfs({ a: null }, '/');
       const dir = new NodeFileSystemDirectoryHandle(fs as any, '/', { mode: 'read' });
       try {
         await dir.removeEntry('a');

--- a/src/node-to-fsa/__tests__/NodeFileSystemFileHandle.test.ts
+++ b/src/node-to-fsa/__tests__/NodeFileSystemFileHandle.test.ts
@@ -3,9 +3,9 @@ import { NodeFileSystemDirectoryHandle } from '../NodeFileSystemDirectoryHandle'
 import { onlyOnNode20 } from '../../__tests__/util';
 
 const setup = (json: DirectoryJSON = {}) => {
-  const fs = memfs(json, '/') as IFsWithVolume;
+  const { fs, vol } = memfs(json, '/');
   const dir = new NodeFileSystemDirectoryHandle(fs as any, '/', { mode: 'readwrite' });
-  return { dir, fs };
+  return { dir, fs, vol };
 };
 
 onlyOnNode20('NodeFileSystemFileHandle', () => {
@@ -27,7 +27,7 @@ onlyOnNode20('NodeFileSystemFileHandle', () => {
 
   describe('.createWritable()', () => {
     test('throws if not in "readwrite" mode', async () => {
-      const fs = memfs({ 'file.txt': 'abc' }, '/') as IFsWithVolume;
+      const { fs } = memfs({ 'file.txt': 'abc' }, '/');
       const dir = new NodeFileSystemDirectoryHandle(fs as any, '/', { mode: 'read' });
       const entry = await dir.getFileHandle('file.txt');
       try {
@@ -139,18 +139,18 @@ onlyOnNode20('NodeFileSystemFileHandle', () => {
       });
 
       test('does not commit changes if .abort() is called and removes the swap file', async () => {
-        const { dir, fs } = setup({
+        const { dir, vol } = setup({
           'file.txt': '...',
         });
         const entry = await dir.getFileHandle('file.txt');
         const writable = await entry.createWritable();
         await writable.write('1');
-        expect(fs.__vol.toJSON()).toStrictEqual({
+        expect(vol.toJSON()).toStrictEqual({
           '/file.txt': '...',
           '/file.txt.crswap': '1',
         });
         await writable.abort();
-        expect(fs.__vol.toJSON()).toStrictEqual({
+        expect(vol.toJSON()).toStrictEqual({
           '/file.txt': '...',
         });
       });

--- a/src/node-to-fsa/__tests__/NodeFileSystemHandle.test.ts
+++ b/src/node-to-fsa/__tests__/NodeFileSystemHandle.test.ts
@@ -3,7 +3,7 @@ import { NodeFileSystemDirectoryHandle } from '../NodeFileSystemDirectoryHandle'
 import { onlyOnNode20 } from '../../__tests__/util';
 
 const setup = (json: DirectoryJSON = {}) => {
-  const fs = memfs(json, '/');
+  const { fs } = memfs(json, '/');
   const dir = new NodeFileSystemDirectoryHandle(fs as any, '/', { mode: 'readwrite' });
   return { dir, fs };
 };

--- a/src/node-to-fsa/__tests__/NodeFileSystemSyncAccessHandle.test.ts
+++ b/src/node-to-fsa/__tests__/NodeFileSystemSyncAccessHandle.test.ts
@@ -4,7 +4,7 @@ import { NodeFileSystemSyncAccessHandle } from '../NodeFileSystemSyncAccessHandl
 import { onlyOnNode20 } from '../../__tests__/util';
 
 const setup = (json: DirectoryJSON = {}) => {
-  const fs = memfs(json, '/');
+  const { fs } = memfs(json, '/');
   const dir = new NodeFileSystemDirectoryHandle(fs as any, '/', { syncHandleAllowed: true, mode: 'readwrite' });
   return { dir, fs };
 };

--- a/src/node-to-fsa/__tests__/NodeFileSystemWritableFileStream.test.ts
+++ b/src/node-to-fsa/__tests__/NodeFileSystemWritableFileStream.test.ts
@@ -4,49 +4,49 @@ import { createSwapFile } from '../NodeFileSystemWritableFileStream';
 
 describe('createSwapFile()', () => {
   test('can create a swap file', async () => {
-    const fs = memfs(
+    const { fs, vol } = memfs(
       {
         '/file.txt': 'Hello, world!',
       },
       '/',
-    ) as IFsWithVolume;
+    );
     const [handle, path] = await createSwapFile(fs, '/file.txt', false);
     expect(handle).toBeInstanceOf(FileHandle);
     expect(path).toBe('/file.txt.crswap');
-    expect(fs.__vol.toJSON()).toStrictEqual({
+    expect(vol.toJSON()).toStrictEqual({
       '/file.txt': 'Hello, world!',
       '/file.txt.crswap': '',
     });
   });
 
   test('can create a swap file at subfolder', async () => {
-    const fs = memfs(
+    const { fs, vol } = memfs(
       {
         '/foo/file.txt': 'Hello, world!',
       },
       '/',
-    ) as IFsWithVolume;
+    );
     const [handle, path] = await createSwapFile(fs, '/foo/file.txt', false);
     expect(handle).toBeInstanceOf(FileHandle);
     expect(path).toBe('/foo/file.txt.crswap');
-    expect(fs.__vol.toJSON()).toStrictEqual({
+    expect(vol.toJSON()).toStrictEqual({
       '/foo/file.txt': 'Hello, world!',
       '/foo/file.txt.crswap': '',
     });
   });
 
   test('can create a swap file when the default swap file name is in use', async () => {
-    const fs = memfs(
+    const { fs, vol } = memfs(
       {
         '/foo/file.txt': 'Hello, world!',
         '/foo/file.txt.crswap': 'lala',
       },
       '/',
-    ) as IFsWithVolume;
+    );
     const [handle, path] = await createSwapFile(fs, '/foo/file.txt', false);
     expect(handle).toBeInstanceOf(FileHandle);
     expect(path).toBe('/foo/file.txt.1.crswap');
-    expect(fs.__vol.toJSON()).toStrictEqual({
+    expect(vol.toJSON()).toStrictEqual({
       '/foo/file.txt': 'Hello, world!',
       '/foo/file.txt.crswap': 'lala',
       '/foo/file.txt.1.crswap': '',
@@ -54,18 +54,18 @@ describe('createSwapFile()', () => {
   });
 
   test('can create a swap file when the first two names are already taken', async () => {
-    const fs = memfs(
+    const { fs, vol } = memfs(
       {
         '/foo/file.txt': 'Hello, world!',
         '/foo/file.txt.crswap': 'lala',
         '/foo/file.txt.1.crswap': 'blah',
       },
       '/',
-    ) as IFsWithVolume;
+    );
     const [handle, path] = await createSwapFile(fs, '/foo/file.txt', false);
     expect(handle).toBeInstanceOf(FileHandle);
     expect(path).toBe('/foo/file.txt.2.crswap');
-    expect(fs.__vol.toJSON()).toStrictEqual({
+    expect(vol.toJSON()).toStrictEqual({
       '/foo/file.txt': 'Hello, world!',
       '/foo/file.txt.crswap': 'lala',
       '/foo/file.txt.1.crswap': 'blah',
@@ -74,7 +74,7 @@ describe('createSwapFile()', () => {
   });
 
   test('can create a swap file when the first three names are already taken', async () => {
-    const fs = memfs(
+    const { fs, vol } = memfs(
       {
         '/foo/file.txt': 'Hello, world!',
         '/foo/file.txt.crswap': 'lala',
@@ -82,11 +82,11 @@ describe('createSwapFile()', () => {
         '/foo/file.txt.2.crswap': 'brawo',
       },
       '/',
-    ) as IFsWithVolume;
+    );
     const [handle, path] = await createSwapFile(fs, '/foo/file.txt', false);
     expect(handle).toBeInstanceOf(FileHandle);
     expect(path).toBe('/foo/file.txt.3.crswap');
-    expect(fs.__vol.toJSON()).toStrictEqual({
+    expect(vol.toJSON()).toStrictEqual({
       '/foo/file.txt': 'Hello, world!',
       '/foo/file.txt.crswap': 'lala',
       '/foo/file.txt.1.crswap': 'blah',
@@ -96,7 +96,7 @@ describe('createSwapFile()', () => {
   });
 
   test('can copy existing data into the swap file', async () => {
-    const fs = memfs(
+    const { fs, vol } = memfs(
       {
         '/foo/file.txt': 'Hello, world!',
         '/foo/file.txt.crswap': 'lala',
@@ -104,11 +104,11 @@ describe('createSwapFile()', () => {
         '/foo/file.txt.2.crswap': 'brawo',
       },
       '/',
-    ) as IFsWithVolume;
+    );
     const [handle, path] = await createSwapFile(fs, '/foo/file.txt', true);
     expect(handle).toBeInstanceOf(FileHandle);
     expect(path).toBe('/foo/file.txt.3.crswap');
-    expect(fs.__vol.toJSON()).toStrictEqual({
+    expect(vol.toJSON()).toStrictEqual({
       '/foo/file.txt': 'Hello, world!',
       '/foo/file.txt.crswap': 'lala',
       '/foo/file.txt.1.crswap': 'blah',

--- a/src/node-to-fsa/__tests__/scenarios.test.ts
+++ b/src/node-to-fsa/__tests__/scenarios.test.ts
@@ -1,15 +1,15 @@
 import { nodeToFsa } from '..';
-import { IFsWithVolume, memfs } from '../..';
+import { memfs } from '../..';
 import { onlyOnNode20 } from '../../__tests__/util';
 
 onlyOnNode20('scenarios', () => {
   test('can init FSA from an arbitrary FS folder and execute operations', async () => {
-    const fs = memfs({
+    const { fs, vol } = memfs({
       '/tmp': null,
       '/etc': null,
       '/bin': null,
       '/Users/kasper/Documents/shopping-list.txt': 'Milk, Eggs, Bread',
-    }) as IFsWithVolume;
+    });
     const dir = nodeToFsa(fs, '/Users/kasper/Documents', { mode: 'readwrite' });
     const shoppingListFile = await dir.getFileHandle('shopping-list.txt');
     const shoppingList = await shoppingListFile.getFile();
@@ -24,7 +24,7 @@ onlyOnNode20('scenarios', () => {
     await logsWritable.write('timestamp,level,message\n');
     await logsWritable.write({ type: 'write', data: '2021-01-01T00:00:00Z,INFO,Hello World\n' });
     await logsWritable.close();
-    expect(fs.__vol.toJSON()).toStrictEqual({
+    expect(vol.toJSON()).toStrictEqual({
       '/tmp': null,
       '/etc': null,
       '/bin': null,

--- a/src/print/__tests__/index.test.ts
+++ b/src/print/__tests__/index.test.ts
@@ -48,3 +48,33 @@ test('can stop recursion at specified depth', () => {
        └─ dir2/ (...)"
   `);
 });
+
+test('can print symlinks', () => {
+  const { fs } = memfs({
+    '/a/b/c/file.txt': '...',
+    '/a/b/main.rb': '...',
+  });
+  fs.symlinkSync('/a/b/c/file.txt', '/goto');
+  expect(toTreeSync(fs)).toMatchInlineSnapshot(`
+    "/
+    ├─ a/
+    │  └─ b/
+    │     ├─ c/
+    │     │  └─ file.txt
+    │     └─ main.rb
+    └─ goto → /a/b/c/file.txt"
+  `);
+});
+
+test('can print starting from subfolder', () => {
+  const { fs } = memfs({
+    '/a/b/c/file.txt': '...',
+    '/a/b/main.rb': '...',
+  });
+  expect(toTreeSync(fs, { dir: '/a/b' })).toMatchInlineSnapshot(`
+    "b/
+    ├─ c/
+    │  └─ file.txt
+    └─ main.rb"
+  `);
+});

--- a/src/print/__tests__/index.test.ts
+++ b/src/print/__tests__/index.test.ts
@@ -1,0 +1,50 @@
+import { toTreeSync } from '..';
+import { memfs } from '../..';
+
+test('can print a single file', () => {
+  const { fs } = memfs({
+    '/file.txt': '...',
+  });
+  expect(toTreeSync(fs, { dir: '/' })).toMatchInlineSnapshot(`
+    "/
+    └─ file.txt"
+  `);
+});
+
+test('can a one level deep directory tree', () => {
+  const { fs } = memfs({
+    '/file.txt': '...',
+    '/foo/bar.txt': '...',
+    '/foo/index.php': '...',
+  });
+  expect(toTreeSync(fs, { dir: '/' })).toMatchInlineSnapshot(`
+    "/
+    ├─ file.txt
+    └─ foo/
+       ├─ bar.txt
+       └─ index.php"
+  `);
+});
+
+test('can print two-levels of folders', () => {
+  const { fs } = memfs({
+    '/level1/level2/file.txt': '...',
+  });
+  expect(toTreeSync(fs, { dir: '/' })).toMatchInlineSnapshot(`
+    "/
+    └─ level1/
+       └─ level2/
+          └─ file.txt"
+  `);
+});
+
+test('can stop recursion at specified depth', () => {
+  const { fs } = memfs({
+    '/dir1/dir2/dir3/file.txt': '...',
+  });
+  expect(toTreeSync(fs, { dir: '/', depth: 2 })).toMatchInlineSnapshot(`
+    "/
+    └─ dir1/
+       └─ dir2/ (...)"
+  `);
+});

--- a/src/print/index.ts
+++ b/src/print/index.ts
@@ -1,7 +1,7 @@
-import {printTree} from 'json-joy/es6/util/print/printTree';
-import {basename} from "../node-to-fsa/util";
-import type {FsSynchronousApi} from "../node/types";
-import type {IDirent} from "../node/types/misc";
+import { printTree } from 'json-joy/es6/util/print/printTree';
+import { basename } from '../node-to-fsa/util';
+import type { FsSynchronousApi } from '../node/types';
+import type { IDirent } from '../node/types/misc';
 
 export const toTreeSync = (fs: FsSynchronousApi, opts: ToTreeOptions = {}) => {
   const separator = opts.separator || '/';
@@ -11,18 +11,19 @@ export const toTreeSync = (fs: FsSynchronousApi, opts: ToTreeOptions = {}) => {
   const depth = opts.depth ?? 10;
   let subtree = ' (...)';
   if (depth > 0) {
-    const list = fs.readdirSync(dir, {withFileTypes: true}) as IDirent[];
-    subtree = printTree(tab, list.map(
-      (entry) => (tab) => {
+    const list = fs.readdirSync(dir, { withFileTypes: true }) as IDirent[];
+    subtree = printTree(
+      tab,
+      list.map(entry => tab => {
         if (entry.isDirectory()) {
-          return toTreeSync(fs, {dir: dir + entry.name, depth: depth - 1, tab});
+          return toTreeSync(fs, { dir: dir + entry.name, depth: depth - 1, tab });
         } else if (entry.isSymbolicLink()) {
           return '' + entry.name + ' → ' + fs.readlinkSync(dir + entry.name);
         } else {
           return '' + entry.name;
         }
-      },
-    ))
+      }),
+    );
   }
   const base = basename(dir, separator) + separator;
   return base + subtree;

--- a/src/print/index.ts
+++ b/src/print/index.ts
@@ -1,0 +1,35 @@
+import {printTree} from 'json-joy/es6/util/print/printTree';
+import {basename} from "../node-to-fsa/util";
+import type {FsSynchronousApi} from "../node/types";
+import type {IDirent} from "../node/types/misc";
+
+export const toTreeSync = (fs: FsSynchronousApi, opts: ToTreeOptions = {}) => {
+  const separator = opts.separator || '/';
+  let dir = opts.dir || separator;
+  if (dir[dir.length - 1] !== separator) dir += separator;
+  const tab = opts.tab || '';
+  const depth = opts.depth ?? 10;
+  let subtree = ' (...)';
+  if (depth > 0) {
+    const list = fs.readdirSync(dir, {withFileTypes: true}) as IDirent[];
+    subtree = printTree(tab, list.map(
+      (entry) => (tab) => {
+        const isDir = entry.isDirectory();
+        if (isDir) {
+          return toTreeSync(fs, {dir: dir + entry.name, depth: depth - 1, tab});
+        } else {
+          return '' + entry.name;
+        }
+      },
+    ))
+  }
+  const base = basename(dir, separator) + separator;
+  return base + subtree;
+};
+
+export interface ToTreeOptions {
+  dir?: string;
+  tab?: string;
+  depth?: number;
+  separator?: '/' | '\\';
+}

--- a/src/print/index.ts
+++ b/src/print/index.ts
@@ -17,6 +17,8 @@ export const toTreeSync = (fs: FsSynchronousApi, opts: ToTreeOptions = {}) => {
         const isDir = entry.isDirectory();
         if (isDir) {
           return toTreeSync(fs, {dir: dir + entry.name, depth: depth - 1, tab});
+        } else if (entry.isSymbolicLink()) {
+          return '' + entry.name + ' → ' + fs.readlinkSync(dir + entry.name);
         } else {
           return '' + entry.name;
         }

--- a/src/print/index.ts
+++ b/src/print/index.ts
@@ -14,8 +14,7 @@ export const toTreeSync = (fs: FsSynchronousApi, opts: ToTreeOptions = {}) => {
     const list = fs.readdirSync(dir, {withFileTypes: true}) as IDirent[];
     subtree = printTree(tab, list.map(
       (entry) => (tab) => {
-        const isDir = entry.isDirectory();
-        if (isDir) {
+        if (entry.isDirectory()) {
           return toTreeSync(fs, {dir: dir + entry.name, depth: depth - 1, tab});
         } else if (entry.isSymbolicLink()) {
           return '' + entry.name + ' → ' + fs.readlinkSync(dir + entry.name);

--- a/src/volume.ts
+++ b/src/volume.ts
@@ -16,6 +16,7 @@ import * as misc from './node/types/misc';
 import * as opts from './node/types/options';
 import { FsCallbackApi } from './node/types/FsCallbackApi';
 import { FsPromises } from './node/FsPromises';
+import {ToTreeOptions, toTreeSync} from './print';
 import { ERRSTR, FLAGS, MODE } from './node/constants';
 import {
   getDefaultOpts,
@@ -603,6 +604,10 @@ export class Volume implements FsCallbackApi {
 
   fromNestedJSON(json: NestedDirectoryJSON, cwd?: string) {
     this.fromJSON(flattenJSON(json), cwd);
+  }
+
+  public toTree(opts?: ToTreeOptions): string {
+    return toTreeSync(this, opts);
   }
 
   reset() {

--- a/src/volume.ts
+++ b/src/volume.ts
@@ -1880,6 +1880,7 @@ export class Volume implements FsCallbackApi {
   public statfsSync: FsSynchronousApi['statfsSync'] = notImplemented;
   public writevSync: FsSynchronousApi['writevSync'] = notImplemented;
   public readvSync: FsSynchronousApi['readvSync'] = notImplemented;
+  public opendirSync: FsSynchronousApi['opendirSync'] = notImplemented;
 
   public cp: FsCallbackApi['cp'] = notImplemented;
   public lutimes: FsCallbackApi['lutimes'] = notImplemented;

--- a/src/volume.ts
+++ b/src/volume.ts
@@ -606,7 +606,7 @@ export class Volume implements FsCallbackApi {
     this.fromJSON(flattenJSON(json), cwd);
   }
 
-  public toTree(opts?: ToTreeOptions): string {
+  public toTree(opts: ToTreeOptions = {separator: <'/' | '\\'>sep}): string {
     return toTreeSync(this, opts);
   }
 

--- a/src/volume.ts
+++ b/src/volume.ts
@@ -16,7 +16,7 @@ import * as misc from './node/types/misc';
 import * as opts from './node/types/options';
 import { FsCallbackApi } from './node/types/FsCallbackApi';
 import { FsPromises } from './node/FsPromises';
-import {ToTreeOptions, toTreeSync} from './print';
+import { ToTreeOptions, toTreeSync } from './print';
 import { ERRSTR, FLAGS, MODE } from './node/constants';
 import {
   getDefaultOpts,
@@ -606,7 +606,7 @@ export class Volume implements FsCallbackApi {
     this.fromJSON(flattenJSON(json), cwd);
   }
 
-  public toTree(opts: ToTreeOptions = {separator: <'/' | '\\'>sep}): string {
+  public toTree(opts: ToTreeOptions = { separator: <'/' | '\\'>sep }): string {
     return toTreeSync(this, opts);
   }
 


### PR DESCRIPTION
Adds ability to print a folder as a text tree:

```ts
import { memfs } from 'memfs';

const { vol } = memfs({
  '/Users/streamich/src/github/memfs/src': {
    'package.json': '...',
    'tsconfig.json': '...',
    'index.ts': '...',
    'util': {
      'index.ts': '...',
      'print': {
        'index.ts': '...',
        'printTree.ts': '...',
      },
    },
  },
});

console.log(vol.toTree());

// Output:
// /
// └─ Users/
//    └─ streamich/
//       └─ src/
//          └─ github/
//             └─ memfs/
//                └─ src/
//                   ├─ index.ts
//                   ├─ package.json
//                   ├─ tsconfig.json
//                   └─ util/
//                      ├─ index.ts
//                      └─ print/
//                         ├─ index.ts
//                         └─ printTree.ts
```