### PR TITLE
fix: add missing nanosecond-precision properties to Stats

### DIFF
--- a/src/Stats.ts
+++ b/src/Stats.ts
@@ -42,6 +42,14 @@ export class Stats<T = TStatNumber> {
     stats.ctimeMs = ctimeMs;
     stats.birthtimeMs = ctimeMs;
 
+    if (bigint) {
+      stats.atimeNs = BigInt(atime.getTime()) * BigInt(1000000);
+      stats.mtimeNs = BigInt(mtime.getTime()) * BigInt(1000000);
+      const ctimeNs = BigInt(ctime.getTime()) * BigInt(1000000);
+      stats.ctimeNs = ctimeNs;
+      stats.birthtimeNs = ctimeNs;
+    }
+
     stats.dev = getStatNumber(0);
     stats.mode = getStatNumber(node.mode);
     stats.nlink = getStatNumber(node.nlink);
@@ -67,6 +75,12 @@ export class Stats<T = TStatNumber> {
   mtimeMs: T;
   ctimeMs: T;
   birthtimeMs: T;
+
+  // additional properties that exist when bigint is true
+  atimeNs: T extends bigint ? T : undefined;
+  mtimeNs: T extends bigint ? T : undefined;
+  ctimeNs: T extends bigint ? T : undefined;
+  birthtimeNs: T extends bigint ? T : undefined;
 
   dev: T;
   mode: T;

--- a/src/__tests__/volume.test.ts
+++ b/src/__tests__/volume.test.ts
@@ -764,6 +764,10 @@ describe('volume', () => {
         if (hasBigInt) {
           const stats = vol.lstatSync('/dojo.js', { bigint: true });
           expect(typeof stats.ino).toBe('bigint');
+          expect(typeof stats.atimeNs).toBe('bigint');
+          expect(typeof stats.mtimeNs).toBe('bigint');
+          expect(typeof stats.ctimeNs).toBe('bigint');
+          expect(typeof stats.birthtimeNs).toBe('bigint');
         } else {
           expect(() => vol.lstatSync('/dojo.js', { bigint: true })).toThrowError();
         }
@@ -795,6 +799,10 @@ describe('volume', () => {
         if (hasBigInt) {
           const stats = vol.statSync('/dojo.js', { bigint: true });
           expect(typeof stats.ino).toBe('bigint');
+          expect(typeof stats.atimeNs).toBe('bigint');
+          expect(typeof stats.mtimeNs).toBe('bigint');
+          expect(typeof stats.ctimeNs).toBe('bigint');
+          expect(typeof stats.birthtimeNs).toBe('bigint');
         } else {
           expect(() => vol.statSync('/dojo.js', { bigint: true })).toThrowError();
         }
@@ -839,6 +847,10 @@ describe('volume', () => {
         if (hasBigInt) {
           const stats = vol.fstatSync(fd, { bigint: true });
           expect(typeof stats.ino).toBe('bigint');
+          expect(typeof stats.atimeNs).toBe('bigint');
+          expect(typeof stats.mtimeNs).toBe('bigint');
+          expect(typeof stats.ctimeNs).toBe('bigint');
+          expect(typeof stats.birthtimeNs).toBe('bigint');
         } else {
           expect(() => vol.fstatSync(fd, { bigint: true })).toThrowError();
         }


### PR DESCRIPTION
Hello, I use memfs for writing unit tests for file system-related Node.js code. I recently noticed that the current implementation of `Stats` lacks nanosecond-precision properties (`atimeNs`, etc.) compared to Node.js one.

This PR adds those properties for better compatibility.

fixes #775 (not sure why it has been closed though)