### PR TITLE
docs: fix link to unionfs

### DIFF
--- a/docs/node/usage.md
+++ b/docs/node/usage.md
@@ -52,6 +52,8 @@ vol2.readFileSync('/foo'); // bar 2
 Use `memfs` together with [`unionfs`][unionfs] to create one filesystem
 from your in-memory volumes and the real disk filesystem:
 
+[unionfs]: https://github.com/streamich/unionfs
+
 ```js
 import * as fs from 'fs';
 import { ufs } from 'unionfs';


### PR DESCRIPTION
Fix link to `unionfs` in [_Usage_](https://github.com/streamich/memfs/blob/252a507/docs/node/usage.md#usage) page.