### PR TITLE
docs: remove a double 'web'

### DIFF
--- a/docs/fsa/fsa-to-fs.md
+++ b/docs/fsa/fsa-to-fs.md
@@ -1,7 +1,7 @@
 # File System Access API to Node `fs` API
 
 This adapter implements Node's `fs`-like filesystem API on top of the web
-web [File System Access (FSA) API][fsa].
+[File System Access (FSA) API][fsa].
 
 This allows you to run Node.js code in browser, for example, run any Node.js
 package that uses `fs` module.


### PR DESCRIPTION
Remove a double _web_ in [_File System Access API to Node fs API_](https://github.com/streamich/memfs/blob/edea9dd/docs/fsa/fsa-to-fs.md#file-system-access-api-to-node-fs-api) page:

> _This adapter implements Node's fs-like filesystem API on top of the **web web** [File System Access (FSA) API](https://developer.mozilla.org/en-US/docs/Web/API/File_System_Access_API)._