### PR TITLE
feat: add support for `recursive` to `readdir`

### DIFF
--- a/src/Dirent.ts
+++ b/src/Dirent.ts
@@ -15,11 +15,13 @@ export class Dirent implements IDirent {
 
     dirent.name = strToEncoding(link.getName(), encoding);
     dirent.mode = mode;
+    dirent.path = link.getPath()
 
     return dirent;
   }
 
   name: TDataOut = '';
+  path: TDataOut = '';
   private mode: number = 0;
 
   private _checkModeProperty(property: number): boolean {

--- a/src/Dirent.ts
+++ b/src/Dirent.ts
@@ -21,7 +21,7 @@ export class Dirent implements IDirent {
   }
 
   name: TDataOut = '';
-  path: TDataOut = '';
+  path = '';
   private mode: number = 0;
 
   private _checkModeProperty(property: number): boolean {

--- a/src/__tests__/volume/readdirSync.test.ts
+++ b/src/__tests__/volume/readdirSync.test.ts
@@ -73,30 +73,42 @@ describe('readdirSync()', () => {
   
   it('accepts option {recursive: true}', () => {
     const vol = create({
-      '/y/af': 'a',
-      '/y/b/bf': 'b',
-      '/y/c/c/cf': 'c',
+      '/y/af1': 'a',
+      '/y/af2': 'a',
+      '/y/b/bf1': 'b',
+      '/y/b/bf2': 'b',
+      '/y/c/c/.cf0': 'c',
+      '/y/c/c/cf1': 'c',
+      '/y/c/c/cf2': 'c',
     });
     const all = vol.readdirSync('/y', { recursive: true });
     (all as any).sort();
-    expect(all).toEqual(['af', 'b', 'b/bf', 'c', 'c/c', 'c/c/cf']);
+    expect(all).toEqual(['af1', 'af2', 'b', 'b/bf1', 'b/bf2', 'c', 'c/c', 'c/c/.cf0', 'c/c/cf1', 'c/c/cf2']);
   });
 
   it('accepts option {recursive: true, withFileTypes: true}', () => {
     const vol = create({
-      '/z/af': 'a',
-      '/z/b/bf': 'b',
-      '/z/c/c/cf': 'c',
+      '/z/af1': 'a',
+      '/z/af2': 'a',
+      '/z/b/bf1': 'b',
+      '/z/b/bf2': 'b',
+      '/z/c/c/.cf0': 'c',
+      '/z/c/c/cf1': 'c',
+      '/z/c/c/cf2': 'c',
     });
     const all = vol.readdirSync('/z', { recursive: true, withFileTypes: true });
     const mapped = all.map((dirent) => { return {...dirent} })
     expect(mapped).toEqual([
-      { mode: 33206, name: 'af', path: '/z/af' },
+      { mode: 33206, name: '.cf0', path: '/z/c/c/.cf0' },
+      { mode: 33206, name: 'af1', path: '/z/af1' },
+      { mode: 33206, name: 'af2', path: '/z/af2' },
       { mode: 16895, name: 'b', path: '/z/b' },
-      { mode: 33206, name: 'bf', path: '/z/b/bf' },
+      { mode: 33206, name: 'bf1', path: '/z/b/bf1' },
+      { mode: 33206, name: 'bf2', path: '/z/b/bf2' },
       { mode: 16895, name: 'c', path: '/z/c' },
       { mode: 16895, name: 'c', path: '/z/c/c' },
-      { mode: 33206, name: 'cf', path: '/z/c/c/cf' },
+      { mode: 33206, name: 'cf1', path: '/z/c/c/cf1' },
+      { mode: 33206, name: 'cf2', path: '/z/c/c/cf2' },
     ]);
   });
 

--- a/src/__tests__/volume/readdirSync.test.ts
+++ b/src/__tests__/volume/readdirSync.test.ts
@@ -55,4 +55,42 @@ describe('readdirSync()', () => {
 
     expect(dirs).toEqual(['foo']);
   });
+
+  it('accepts option {withFileTypes: true}', () => {
+    const vol = create({
+      '/x/a': 'a',
+      '/x/b/b': 'b',
+      '/x/c/c/c': 'c',
+    });
+    const all = vol.readdirSync('/x', { withFileTypes: true });
+    const mapped = all.map((dirent) => { return {...dirent} })
+    expect(mapped).toEqual([
+      { mode: 33206, name: 'a', path: '/x/a' },
+      { mode: 16895, name: 'b', path: '/x/b' },
+      { mode: 16895, name: 'c', path: '/x/c' },
+    ]);
+  });
+  
+  it('accepts option {recursive: true}', () => {
+    const vol = create({
+      '/y/a': 'a',
+      '/y/b/b': 'b',
+      '/y/c/c/c': 'c',
+    });
+    const all = vol.readdirSync('/y', { recursive: true });
+    (all as any).sort();
+    expect(all).toEqual(['a', 'b', 'b/b', 'c', 'c/c', 'c/c/c']);
+  });
+
+  it('accepts option {recursive: true, withFileTypes: true}', () => {
+    const vol = create({
+      '/z/a': 'a',
+      '/z/b/b': 'b',
+      '/z/c/c/c': 'c',
+    });
+    const all = vol.readdirSync('/z', { recursive: true });
+    (all as any).sort();
+    expect(all).toEqual(['a/a', 'a/b', 'a/b/b', 'a/c', 'a/c/c', 'a/c/c/c']);
+  });
+
 });

--- a/src/__tests__/volume/readdirSync.test.ts
+++ b/src/__tests__/volume/readdirSync.test.ts
@@ -58,14 +58,14 @@ describe('readdirSync()', () => {
 
   it('accepts option {withFileTypes: true}', () => {
     const vol = create({
-      '/x/a': 'a',
-      '/x/b/b': 'b',
-      '/x/c/c/c': 'c',
+      '/x/af': 'a',
+      '/x/b/bf': 'b',
+      '/x/c/c/cf': 'c',
     });
     const all = vol.readdirSync('/x', { withFileTypes: true });
     const mapped = all.map((dirent) => { return {...dirent} })
     expect(mapped).toEqual([
-      { mode: 33206, name: 'a', path: '/x/a' },
+      { mode: 33206, name: 'af', path: '/x/af' },
       { mode: 16895, name: 'b', path: '/x/b' },
       { mode: 16895, name: 'c', path: '/x/c' },
     ]);
@@ -73,24 +73,31 @@ describe('readdirSync()', () => {
   
   it('accepts option {recursive: true}', () => {
     const vol = create({
-      '/y/a': 'a',
-      '/y/b/b': 'b',
-      '/y/c/c/c': 'c',
+      '/y/af': 'a',
+      '/y/b/bf': 'b',
+      '/y/c/c/cf': 'c',
     });
     const all = vol.readdirSync('/y', { recursive: true });
     (all as any).sort();
-    expect(all).toEqual(['a', 'b', 'b/b', 'c', 'c/c', 'c/c/c']);
+    expect(all).toEqual(['af', 'b', 'b/bf', 'c', 'c/c', 'c/c/cf']);
   });
 
   it('accepts option {recursive: true, withFileTypes: true}', () => {
     const vol = create({
-      '/z/a': 'a',
-      '/z/b/b': 'b',
-      '/z/c/c/c': 'c',
+      '/z/af': 'a',
+      '/z/b/bf': 'b',
+      '/z/c/c/cf': 'c',
     });
-    const all = vol.readdirSync('/z', { recursive: true });
-    (all as any).sort();
-    expect(all).toEqual(['a/a', 'a/b', 'a/b/b', 'a/c', 'a/c/c', 'a/c/c/c']);
+    const all = vol.readdirSync('/z', { recursive: true, withFileTypes: true });
+    const mapped = all.map((dirent) => { return {...dirent} })
+    expect(mapped).toEqual([
+      { mode: 33206, name: 'af', path: '/z/af' },
+      { mode: 16895, name: 'b', path: '/z/b' },
+      { mode: 33206, name: 'bf', path: '/z/b/bf' },
+      { mode: 16895, name: 'c', path: '/z/c' },
+      { mode: 16895, name: 'c', path: '/z/c/c' },
+      { mode: 33206, name: 'cf', path: '/z/c/c/cf' },
+    ]);
   });
 
 });

--- a/src/node/options.ts
+++ b/src/node/options.ts
@@ -73,6 +73,7 @@ export const getReadFileOptions = optsGenerator<opts.IReadFileOptions>(readFileO
 
 const readdirDefaults: opts.IReaddirOptions = {
   encoding: 'utf8',
+  recursive: false,
   withFileTypes: false,
 };
 export const getReaddirOptions = optsGenerator<opts.IReaddirOptions>(readdirDefaults);

--- a/src/node/types/options.ts
+++ b/src/node/types/options.ts
@@ -33,6 +33,7 @@ export interface IFStatOptions {
 export interface IAppendFileOptions extends IFileOptions {}
 
 export interface IReaddirOptions extends IOptions {
+  recursive?: boolean
   withFileTypes?: boolean;
 }
 

--- a/src/volume.ts
+++ b/src/volume.ts
@@ -1472,12 +1472,9 @@ export class Volume implements FsCallbackApi, FsSynchronousApi {
       list.push(Dirent.build(child, options.encoding));
 
       // recursion
-      if (options.recursive && child.getNode().isDirectory()) {
-        // console.log("child", child)
-        // console.log('child.getNode()', child.getNode())
-        const childFilename = join(child.getPath(), child.getName())
-        console.log('child.getNode().isDirectory()', child.getNode().isDirectory(), childFilename)
-        const childList = this.readdirBase(childFilename, { recursive: true, withFileTypes: true }) as Dirent[]
+      if (options.recursive && child.children.size) {
+        const recurseOptions = { ...options, ecursive: true, withFileTypes: true }
+        const childList = this.readdirBase(child.getPath(), recurseOptions) as Dirent[]
         list.push(...childList)
       }
     }
@@ -1492,13 +1489,13 @@ export class Volume implements FsCallbackApi, FsSynchronousApi {
     if (options.withFileTypes) return list;
 
     const ret: TDataOut[] = [];
-    for (const name of link.children.keys()) {
-      if (name === '.' || name === '..') continue;
-      ret.push(strToEncoding(name, options.encoding));
-    }
 
-    if (!isWin && options.encoding !== 'buffer') ret.sort();
-    return ret;
+    return list.map(dirent => {
+      if (options.recursive) {
+        return dirent.path.replace(filename + pathModule.sep, '')
+      }
+      return dirent.name
+    })
   }
 
   readdirSync(path: PathLike, options?: opts.IReaddirOptions | string): TDataOut[] | Dirent[] {

--- a/src/volume.ts
+++ b/src/volume.ts
@@ -1473,7 +1473,7 @@ export class Volume implements FsCallbackApi, FsSynchronousApi {
 
       // recursion
       if (options.recursive && child.children.size) {
-        const recurseOptions = { ...options, ecursive: true, withFileTypes: true }
+        const recurseOptions = { ...options, recursive: true, withFileTypes: true }
         const childList = this.readdirBase(child.getPath(), recurseOptions) as Dirent[]
         list.push(...childList)
       }


### PR DESCRIPTION
Fix readdir recursive option and path to Dirent when withFileTypes: true

There wasn't a good way to do {recursive: true, withFileTypes: false} without making too many code paths.

I refactored it to calculate the data needed for { withFileTypes: true }, made a code path for function recursion if ( recursive: true }, and then original call returns just the paths if it's options were {withFileTypes: false} 

There may be a better way to do it, but that's what I got from my first look in the code.

Resolves #967