### PR TITLE
fix: use internal buffer instead of global Buffer

### DIFF
--- a/src/fsa-to-node/FsaNodeFs.ts
+++ b/src/fsa-to-node/FsaNodeFs.ts
@@ -1,5 +1,6 @@
 import * as optHelpers from '../node/options';
 import * as util from '../node/util';
+import { Buffer } from '../internal/buffer';
 import { FsPromises } from '../node/FsPromises';
 import { pathToLocation, testDirectoryIsWritable } from './util';
 import { ERRSTR, MODE } from '../node/constants';

--- a/src/node-to-fsa/NodeFileSystemSyncAccessHandle.ts
+++ b/src/node-to-fsa/NodeFileSystemSyncAccessHandle.ts
@@ -1,4 +1,5 @@
 import { assertCanWrite } from './util';
+import { Buffer } from '../internal/buffer';
 import type { FileSystemReadWriteOptions, IFileSystemSyncAccessHandle } from '../fsa/types';
 import type { NodeFsaContext, NodeFsaFs } from './types';
 

--- a/src/node-to-fsa/NodeFileSystemWritableFileStream.ts
+++ b/src/node-to-fsa/NodeFileSystemWritableFileStream.ts
@@ -1,3 +1,4 @@
+import { Buffer } from '../internal/buffer';
 import type { Data, FileSystemWritableFileStreamParams, IFileSystemWritableFileStream } from '../fsa/types';
 import type { IFileHandle } from '../node/types/misc';
 import type { NodeFsaFs } from './types';

--- a/src/node.ts
+++ b/src/node.ts
@@ -1,5 +1,5 @@
 import process from './process';
-import { bufferAllocUnsafe, bufferFrom } from './internal/buffer';
+import { Buffer, bufferAllocUnsafe, bufferFrom } from './internal/buffer';
 import { constants, S } from './constants';
 import { Volume } from './volume';
 import { EventEmitter } from 'events';

--- a/src/node/util.ts
+++ b/src/node/util.ts
@@ -1,5 +1,6 @@
 import { ERRSTR, FLAGS } from './constants';
 import * as errors from '../internal/errors';
+import { Buffer } from '../internal/buffer';
 import type { FsCallbackApi } from './types';
 import type * as misc from './types/misc';
 import { ENCODING_UTF8, TEncodingExtended } from '../encoding';

--- a/src/webfs/index.ts
+++ b/src/webfs/index.ts
@@ -1,5 +1,4 @@
 (<any>self).process = require('process/browser');
-(<any>self).Buffer = require('buffer').Buffer;
 
 import { FsaNodeFs, FsaNodeSyncAdapterWorker } from '../fsa-to-node';
 import { FsaNodeSyncWorker } from '../../src/fsa-to-node/worker/FsaNodeSyncWorker';


### PR DESCRIPTION
This prevents the need to shim Buffer on window in a browser based project, which reduces complexity in the build chain for such projects.