### PR TITLE
feat: make `json-joy` and `thingies` dependencies optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,10 +120,7 @@
       "^.+\\.tsx?$": "ts-jest"
     }
   },
-  "dependencies": {
-    "json-joy": "^11.0.0",
-    "thingies": "^1.11.1"
-  },
+  "dependencies": {},
   "devDependencies": {
     "@semantic-release/changelog": "^6.0.1",
     "@semantic-release/git": "^10.0.1",
@@ -137,6 +134,7 @@
     "husky": "^8.0.1",
     "isomorphic-git": "^1.24.2",
     "jest": "^29.0.0",
+    "json-joy": "^11.0.0",
     "path-browserify": "^1.0.1",
     "prettier": "^2.7.1",
     "pretty-quick": "^4.0.0",
@@ -145,6 +143,7 @@
     "rimraf": "^5.0.0",
     "semantic-release": "^19.0.3",
     "tar-stream": "^3.1.2",
+    "thingies": "^1.11.1",
     "ts-jest": "^29.1.0",
     "ts-loader": "^9.4.3",
     "ts-node": "^10.9.1",
@@ -158,7 +157,17 @@
     "webpack-dev-server": "^4.15.1"
   },
   "peerDependencies": {
+    "json-joy": "^11.0.0",
+    "thingies": "^1.11.1",
     "tslib": "2"
+  },
+  "peerDependenciesMeta": {
+    "json-joy": {
+      "optional": true
+    },
+    "thingies": {
+      "optional": true
+    }
   },
   "engines": {
     "node": ">= 4.0.0"


### PR DESCRIPTION
This is arguably breaking but `json-joy` is 30mb on disk and not required for the core fs system which I think is what most people are using so I'm willing to risk it in a minor version

Going to land it in a pre-release first to test - alternatively we could just inline the functions we're using from these dependencies. 