### PR TITLE
fix: make `tslib` a direct dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,7 +122,8 @@
   },
   "dependencies": {
     "json-joy": "^11.0.0",
-    "thingies": "^1.11.1"
+    "thingies": "^1.11.1",
+    "tslib": "^2.0.0"
   },
   "devDependencies": {
     "@semantic-release/changelog": "^6.0.1",
@@ -156,9 +157,6 @@
     "webpack": "^5.87.0",
     "webpack-cli": "^5.1.4",
     "webpack-dev-server": "^4.15.1"
-  },
-  "peerDependencies": {
-    "tslib": "2"
   },
   "engines": {
     "node": ">= 4.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6872,7 +6872,7 @@ tslib@^1.13.0, tslib@^1.8.1:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.0.3, tslib@^2.6.2:
+tslib@^2.0.0, tslib@^2.0.3, tslib@^2.6.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.2.tgz#703ac29425e7b37cd6fd456e92404d46d1f3e4ae"
   integrity sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==


### PR DESCRIPTION
This doesn't need to be a peer dependency since its used directly and its safe for multiple versions to exist on the tree