### PR TITLE
fix: fix name validation regex to accept file names beginning with a period

### DIFF
--- a/src/node-to-fsa/__tests__/NodeFileSystemDirectoryHandle.test.ts
+++ b/src/node-to-fsa/__tests__/NodeFileSystemDirectoryHandle.test.ts
@@ -303,6 +303,12 @@ onlyOnNode20('NodeFileSystemDirectoryHandle', () => {
       });
     }
 
+    test(`accepts file names beginning with a .`, async () => {
+      const { dir } = setup({ '.hidden': 'contents' });
+      const fileHandle = await dir.getFileHandle('.hidden');
+      expect(fileHandle).toBeInstanceOf(NodeFileSystemFileHandle);
+    });
+
     test('can retrieve a child file', async () => {
       const { dir } = setup({ file: 'contents', subdir: null });
       const subdir = await dir.getFileHandle('file');

--- a/src/node-to-fsa/__tests__/NodeFileSystemDirectoryHandle.test.ts
+++ b/src/node-to-fsa/__tests__/NodeFileSystemDirectoryHandle.test.ts
@@ -303,7 +303,7 @@ onlyOnNode20('NodeFileSystemDirectoryHandle', () => {
       });
     }
 
-    test(`accepts file names beginning with a .`, async () => {
+    test('accepts file names beginning with a .', async () => {
       const { dir } = setup({ '.hidden': 'contents' });
       const fileHandle = await dir.getFileHandle('.hidden');
       expect(fileHandle).toBeInstanceOf(NodeFileSystemFileHandle);

--- a/src/node-to-fsa/util.ts
+++ b/src/node-to-fsa/util.ts
@@ -18,7 +18,7 @@ export const basename = (path: string, separator: string) => {
   return lastSlashIndex === -1 ? path : path.slice(lastSlashIndex + 1);
 };
 
-const nameRegex = /^(\.{1,2})|(.*(\/|\\).*)$/;
+const nameRegex = /^(\.{1,2})$|^(.*([\/\\]).*)$/;
 
 export const assertName = (name: string, method: string, klass: string) => {
   const isInvalid = !name || nameRegex.test(name);


### PR DESCRIPTION
Hi,

I was using node-to-fsa and realized that files beginning with a period, as in hidden *nix files, throw 

```typescript
new TypeError(`Failed to execute '${method}' on '${klass}': Name is not allowed.`);
```
from `src/node-to-fsa/util.ts:assertName`.

I am assuming that this is not an intended behavior, if this is a correct assumption, please accept my pull request.

I modified the regex and added a regression test case.