### PR TITLE
fix: fix handle paths in FSA entries iterator

### DIFF
--- a/src/node-to-fsa/NodeFileSystemDirectoryHandle.ts
+++ b/src/node-to-fsa/NodeFileSystemDirectoryHandle.ts
@@ -57,7 +57,7 @@ export class NodeFileSystemDirectoryHandle extends NodeFileSystemHandle implemen
     for (const d of list) {
       const dirent = d as Dirent;
       const name = dirent.name + '';
-      const newPath = path + ctx.separator! + name;
+      const newPath = path + name;
       if (dirent.isDirectory()) yield [name, new NodeFileSystemDirectoryHandle(fs, newPath, ctx)];
       else if (dirent.isFile()) yield [name, new NodeFileSystemFileHandle(fs, newPath, ctx)];
     }

--- a/src/node-to-fsa/NodeFileSystemDirectoryHandle.ts
+++ b/src/node-to-fsa/NodeFileSystemDirectoryHandle.ts
@@ -59,7 +59,7 @@ export class NodeFileSystemDirectoryHandle extends NodeFileSystemHandle implemen
       const name = dirent.name + '';
       const newPath = path + ctx.separator! + name;
       if (dirent.isDirectory()) yield [name, new NodeFileSystemDirectoryHandle(fs, newPath, ctx)];
-      else if (dirent.isFile()) yield [name, new NodeFileSystemFileHandle(fs, name, ctx)];
+      else if (dirent.isFile()) yield [name, new NodeFileSystemFileHandle(fs, newPath, ctx)];
     }
   }
 

--- a/src/node-to-fsa/__tests__/NodeFileSystemDirectoryHandle.test.ts
+++ b/src/node-to-fsa/__tests__/NodeFileSystemDirectoryHandle.test.ts
@@ -64,6 +64,7 @@ onlyOnNode20('NodeFileSystemDirectoryHandle', () => {
         expect(subdir).toBeInstanceOf(NodeFileSystemDirectoryHandle);
         expect(subdir.kind).toBe('directory');
         expect(subdir.name).toBe('My Documents');
+        expect((subdir as NodeFileSystemDirectoryHandle).__path).toBe('/My Documents/');
       }
     });
 

--- a/src/node-to-fsa/__tests__/NodeFileSystemDirectoryHandle.test.ts
+++ b/src/node-to-fsa/__tests__/NodeFileSystemDirectoryHandle.test.ts
@@ -76,6 +76,7 @@ onlyOnNode20('NodeFileSystemDirectoryHandle', () => {
         expect(file).toBeInstanceOf(NodeFileSystemFileHandle);
         expect(file.kind).toBe('file');
         expect(file.name).toBe('file.txt');
+        await expect((file as NodeFileSystemFileHandle).getFile()).resolves.toBeInstanceOf(File);
       }
     });
 


### PR DESCRIPTION
Hi! Thanks for working on this library. The File System Access API adapter has been helpful for testing a project I'm working on.

I noticed in one of my test suites that when using file handles retrieved from the `NodeFileSystemDirectoryHandle.entries()` async iterator, the `getFile()` method would throw an ENOENT error, with the message suggesting it was trying to read the file using just the name instead of the full path.

This appears to be a typo in the implementation, so I changed it to pass the full path when constructing file handles and added an assertion to the relevant test case that checks that the file entries can be read.