### PR TITLE
feat: adding optional file/path to node-to-fsa thrown DOMException  enhance error reporting.

### DIFF
--- a/src/node-to-fsa/NodeFileSystemDirectoryHandle.ts
+++ b/src/node-to-fsa/NodeFileSystemDirectoryHandle.ts
@@ -91,7 +91,7 @@ export class NodeFileSystemDirectoryHandle extends NodeFileSystemHandle implemen
     const filename = this.__path + name;
     try {
       const stats = await this.fs.promises.stat(filename);
-      if (!stats.isDirectory()) throw newTypeMismatchError();
+      if (!stats.isDirectory()) throw newTypeMismatchError(filename);
       return new NodeFileSystemDirectoryHandle(this.fs, filename, this.ctx);
     } catch (error) {
       if (error instanceof DOMException) throw error;
@@ -103,7 +103,7 @@ export class NodeFileSystemDirectoryHandle extends NodeFileSystemHandle implemen
               await this.fs.promises.mkdir(filename);
               return new NodeFileSystemDirectoryHandle(this.fs, filename, this.ctx);
             }
-            throw newNotFoundError();
+            throw newNotFoundError(filename);
           }
           case 'EPERM':
           case 'EACCES':
@@ -128,7 +128,7 @@ export class NodeFileSystemDirectoryHandle extends NodeFileSystemHandle implemen
     const filename = this.__path + name;
     try {
       const stats = await this.fs.promises.stat(filename);
-      if (!stats.isFile()) throw newTypeMismatchError();
+      if (!stats.isFile()) throw newTypeMismatchError(filename);
       return new NodeFileSystemFileHandle(this.fs, filename, this.ctx);
     } catch (error) {
       if (error instanceof DOMException) throw error;
@@ -140,7 +140,7 @@ export class NodeFileSystemDirectoryHandle extends NodeFileSystemHandle implemen
               await this.fs.promises.writeFile(filename, '');
               return new NodeFileSystemFileHandle(this.fs, filename, this.ctx);
             }
-            throw newNotFoundError();
+            throw newNotFoundError(filename);
           }
           case 'EPERM':
           case 'EACCES':
@@ -171,13 +171,13 @@ export class NodeFileSystemDirectoryHandle extends NodeFileSystemHandle implemen
         await promises.unlink(filename);
       } else if (stats.isDirectory()) {
         await promises.rmdir(filename, { recursive });
-      } else throw newTypeMismatchError();
+      } else throw newTypeMismatchError(filename);
     } catch (error) {
       if (error instanceof DOMException) throw error;
       if (error && typeof error === 'object') {
         switch (error.code) {
           case 'ENOENT': {
-            throw newNotFoundError();
+            throw newNotFoundError(filename);
           }
           case 'EPERM':
           case 'EACCES':

--- a/src/node-to-fsa/NodeFileSystemFileHandle.ts
+++ b/src/node-to-fsa/NodeFileSystemFileHandle.ts
@@ -39,7 +39,7 @@ export class NodeFileSystemFileHandle extends NodeFileSystemHandle implements IF
         switch (error.code) {
           case 'EPERM':
           case 'EACCES':
-            throw newNotAllowedError();
+            throw newNotAllowedError(this.__path);
         }
       }
       throw error;

--- a/src/node-to-fsa/__tests__/NodeFileSystemDirectoryHandle.test.ts
+++ b/src/node-to-fsa/__tests__/NodeFileSystemDirectoryHandle.test.ts
@@ -144,7 +144,7 @@ onlyOnNode20('NodeFileSystemDirectoryHandle', () => {
         expect(error).toBeInstanceOf(DOMException);
         expect(error.name).toBe('NotFoundError');
         expect(error.message).toBe(
-          'A requested file or directory could not be found at the time an operation was processed.',
+          'A requested file or directory could not be found at the time an operation was processed: /b.',
         );
       }
     });
@@ -157,7 +157,7 @@ onlyOnNode20('NodeFileSystemDirectoryHandle', () => {
       } catch (error) {
         expect(error).toBeInstanceOf(DOMException);
         expect(error.name).toBe('TypeMismatchError');
-        expect(error.message).toBe('The path supplied exists, but was not an entry of requested type.');
+        expect(error.message).toBe('The path supplied exists, but was not an entry of requested type: /file.');
       }
     });
 
@@ -239,7 +239,7 @@ onlyOnNode20('NodeFileSystemDirectoryHandle', () => {
         expect(error).toBeInstanceOf(DOMException);
         expect(error.name).toBe('NotFoundError');
         expect(error.message).toBe(
-          'A requested file or directory could not be found at the time an operation was processed.',
+          'A requested file or directory could not be found at the time an operation was processed: /b.',
         );
       }
     });
@@ -252,7 +252,7 @@ onlyOnNode20('NodeFileSystemDirectoryHandle', () => {
       } catch (error) {
         expect(error).toBeInstanceOf(DOMException);
         expect(error.name).toBe('TypeMismatchError');
-        expect(error.message).toBe('The path supplied exists, but was not an entry of requested type.');
+        expect(error.message).toBe('The path supplied exists, but was not an entry of requested type: /directory.');
       }
     });
 
@@ -341,7 +341,7 @@ onlyOnNode20('NodeFileSystemDirectoryHandle', () => {
         expect(error).toBeInstanceOf(DOMException);
         expect(error.name).toBe('NotFoundError');
         expect(error.message).toBe(
-          'A requested file or directory could not be found at the time an operation was processed.',
+          'A requested file or directory could not be found at the time an operation was processed: /b.',
         );
       }
     });

--- a/src/node-to-fsa/util.ts
+++ b/src/node-to-fsa/util.ts
@@ -33,13 +33,13 @@ export const assertCanWrite = (mode: 'read' | 'readwrite') => {
     );
 };
 
-export const newNotFoundError = () =>
+export const newNotFoundError = (filename?: string) =>
   new DOMException(
-    'A requested file or directory could not be found at the time an operation was processed.',
+    `A requested file or directory could not be found at the time an operation was processed${filename ? ': ' + filename : ''}.`,
     'NotFoundError',
   );
 
-export const newTypeMismatchError = () =>
-  new DOMException('The path supplied exists, but was not an entry of requested type.', 'TypeMismatchError');
+export const newTypeMismatchError = (path?: string) =>
+  new DOMException(`The path supplied exists, but was not an entry of requested type${path ? ': ' + path : ''}.`, 'TypeMismatchError');
 
-export const newNotAllowedError = () => new DOMException('Permission not granted.', 'NotAllowedError');
+export const newNotAllowedError = (path?: string) => new DOMException(`Permission not granted${path ? ': ' + path : ''}.`, 'NotAllowedError');

--- a/src/node-to-fsa/util.ts
+++ b/src/node-to-fsa/util.ts
@@ -40,6 +40,10 @@ export const newNotFoundError = (filename?: string) =>
   );
 
 export const newTypeMismatchError = (path?: string) =>
-  new DOMException(`The path supplied exists, but was not an entry of requested type${path ? ': ' + path : ''}.`, 'TypeMismatchError');
+  new DOMException(
+    `The path supplied exists, but was not an entry of requested type${path ? ': ' + path : ''}.`,
+    'TypeMismatchError',
+  );
 
-export const newNotAllowedError = (path?: string) => new DOMException(`Permission not granted${path ? ': ' + path : ''}.`, 'NotAllowedError');
+export const newNotAllowedError = (path?: string) =>
+  new DOMException(`Permission not granted${path ? ': ' + path : ''}.`, 'NotAllowedError');


### PR DESCRIPTION
Hi,

I was using `node-to-fsa` and was getting `DOMException`s of different types, but it wasn't easy to figure out which files were related to these exceptions. 

I added the file/path as a parameter to the exception constructors to assist with debugging and troubleshooting, and I modified test cases accordingly.