### PR TITLE
fix: ensure files in subdirectories are returned as buffers when calling `toJSON` with `asBuffer`

### DIFF
--- a/src/__tests__/volume.test.ts
+++ b/src/__tests__/volume.test.ts
@@ -196,6 +196,15 @@ describe('volume', () => {
         const result = vol.toJSON('/', {}, false, true)['/file'];
         expect(result).toStrictEqual(buffer);
       });
+
+      it('Outputs files in subdirectories as buffers too', () => {
+        const buffer = Buffer.from('Hello');
+        const vol = new Volume();
+        vol.mkdirSync('/dir');
+        vol.writeFileSync('/dir/file', buffer);
+        const result = vol.toJSON('/', {}, false, true)['/dir/file'];
+        expect(result).toStrictEqual(buffer);
+      });
     });
 
     describe('.fromJSON(json[, cwd])', () => {

--- a/src/volume.ts
+++ b/src/volume.ts
@@ -554,7 +554,7 @@ export class Volume implements FsCallbackApi, FsSynchronousApi {
         if (path) filename = relative(path, filename);
         json[filename] = asBuffer ? node.getBuffer() : node.getString();
       } else if (node.isDirectory()) {
-        this._toJSON(child, json, path);
+        this._toJSON(child, json, path, asBuffer);
       }
     }
 


### PR DESCRIPTION
Without that, `asBuffer` only works for files at the root of the volume, not those in sub-directories.