### PR TITLE
fix: add `parentPath` to `Dirent`

### DIFF
--- a/src/Dirent.ts
+++ b/src/Dirent.ts
@@ -16,12 +16,14 @@ export class Dirent implements IDirent {
     dirent.name = strToEncoding(link.getName(), encoding);
     dirent.mode = mode;
     dirent.path = link.getParentPath();
+    dirent.parentPath = dirent.path;
 
     return dirent;
   }
 
   name: TDataOut = '';
   path = '';
+  parentPath = '';
   private mode: number = 0;
 
   private _checkModeProperty(property: number): boolean {

--- a/src/__tests__/volume/readdirSync.test.ts
+++ b/src/__tests__/volume/readdirSync.test.ts
@@ -67,9 +67,9 @@ describe('readdirSync()', () => {
       return { ...dirent };
     });
     expect(mapped).toEqual([
-      { mode: 33206, name: 'af', path: '/x' },
-      { mode: 16895, name: 'b', path: '/x' },
-      { mode: 16895, name: 'c', path: '/x' },
+      { mode: 33206, name: 'af', path: '/x', parentPath: '/x' },
+      { mode: 16895, name: 'b', path: '/x', parentPath: '/x' },
+      { mode: 16895, name: 'c', path: '/x', parentPath: '/x' },
     ]);
   });
 
@@ -105,16 +105,16 @@ describe('readdirSync()', () => {
       })
       .sort((a, b) => a.path.localeCompare(b.path));
     expect(mapped).toEqual([
-      { mode: 33206, name: 'af1', path: '/z' },
-      { mode: 33206, name: 'af2', path: '/z' },
-      { mode: 16895, name: 'b', path: '/z' },
-      { mode: 16895, name: 'c', path: '/z' },
-      { mode: 33206, name: 'bf1', path: '/z/b' },
-      { mode: 33206, name: 'bf2', path: '/z/b' },
-      { mode: 16895, name: 'c', path: '/z/c' },
-      { mode: 33206, name: '.cf0', path: '/z/c/c' },
-      { mode: 33206, name: 'cf1', path: '/z/c/c' },
-      { mode: 33206, name: 'cf2', path: '/z/c/c' },
+      { mode: 33206, name: 'af1', path: '/z', parentPath: '/z' },
+      { mode: 33206, name: 'af2', path: '/z', parentPath: '/z' },
+      { mode: 16895, name: 'b', path: '/z', parentPath: '/z' },
+      { mode: 16895, name: 'c', path: '/z', parentPath: '/z' },
+      { mode: 33206, name: 'bf1', path: '/z/b', parentPath: '/z/b' },
+      { mode: 33206, name: 'bf2', path: '/z/b', parentPath: '/z/b' },
+      { mode: 16895, name: 'c', path: '/z/c', parentPath: '/z/c' },
+      { mode: 33206, name: '.cf0', path: '/z/c/c', parentPath: '/z/c/c' },
+      { mode: 33206, name: 'cf1', path: '/z/c/c', parentPath: '/z/c/c' },
+      { mode: 33206, name: 'cf2', path: '/z/c/c', parentPath: '/z/c/c' },
     ]);
   });
 });

--- a/src/volume.ts
+++ b/src/volume.ts
@@ -1499,7 +1499,7 @@ export class Volume implements FsCallbackApi, FsSynchronousApi {
 
     return list.map(dirent => {
       if (options.recursive) {
-        let fullPath = pathModule.join(dirent.path, dirent.name.toString());
+        let fullPath = pathModule.join(dirent.parentPath, dirent.name.toString());
         if (isWin) {
           fullPath = fullPath.replace(/\\/g, '/');
         }


### PR DESCRIPTION
# Changes

- Add missing `parentPath` property to `Dirent` which is equal to the `path` property

The `parentPath` property will replace the `path` property on `Dirent` in future node versions (see [Docs](https://nodejs.org/api/fs.html#class-fsdirent)).

References #735