### PR TITLE
feat: support stream as source in promises version of `writeFile`

### DIFF
--- a/src/__tests__/promises.test.ts
+++ b/src/__tests__/promises.test.ts
@@ -1,4 +1,5 @@
 import { Volume } from '../volume';
+import { Readable } from 'stream';
 
 describe('Promises API', () => {
   describe('FileHandle', () => {
@@ -703,6 +704,22 @@ describe('Promises API', () => {
       await promises.writeFile(fileHandle, 'bar');
       expect(vol.readFileSync('/foo').toString()).toEqual('bar');
       await fileHandle.close();
+    });
+    it('Write data to an existing file using stream as source', async () => {
+      const vol = new Volume();
+      const { promises } = vol;
+      vol.fromJSON({
+        '/foo': '',
+      });
+      const text = 'bar';
+      const stream = new Readable({
+        read() {
+          this.push(text);
+          this.push(null);
+        },
+      });
+      await promises.writeFile('/foo', stream);
+      expect(vol.readFileSync('/foo').toString()).toEqual(text);
     });
     it('Reject when trying to write on a directory', () => {
       const vol = new Volume();

--- a/src/node/types/FsPromisesApi.ts
+++ b/src/node/types/FsPromisesApi.ts
@@ -37,5 +37,5 @@ export interface FsPromisesApi {
     filename: misc.PathLike,
     options?: opts.IWatchOptions,
   ): AsyncIterableIterator<{ eventType: string; filename: string | Buffer }>;
-  writeFile(id: misc.TFileHandle, data: misc.TData, options?: opts.IWriteFileOptions): Promise<void>;
+  writeFile(id: misc.TFileHandle, data: misc.TPromisesData, options?: opts.IWriteFileOptions): Promise<void>;
 }

--- a/src/node/types/misc.ts
+++ b/src/node/types/misc.ts
@@ -17,6 +17,7 @@ export type TDataOut = string | Buffer; // Data formats we give back to users.
 export type TEncodingExtended = BufferEncoding | 'buffer';
 export type TFileId = PathLike | number; // Number is used as a file descriptor.
 export type TData = TDataOut | ArrayBufferView | DataView; // Data formats users can give us.
+export type TPromisesData = TData | Readable; // Data formats users can give us in the promises API.
 export type TFlags = string | number;
 export type TMode = string | number; // Mode can be a String, although docs say it should be a Number.
 export type TTime = number | string | Date;


### PR DESCRIPTION
Now supporting streams as `writeFile()` data source in the Promises API, which makes it more compliant to the [Node.js Promises API](https://nodejs.org/docs/latest-v20.x/api/fs.html#fspromiseswritefilefile-data-options).

What's still missing is the support for `AsyncIterable` and `Iterable`. I can implement them as well if this PR gets approved.

Closes #1068