### PR TITLE
feat: implement `createReadStream` and `createWriteStream` on `FileHandle`

### DIFF
--- a/src/node/FileHandle.ts
+++ b/src/node/FileHandle.ts
@@ -1,6 +1,6 @@
 import { promisify } from './util';
 import type * as opts from './types/options';
-import type { IFileHandle, IStats, TData, TDataOut, TMode, TTime } from './types/misc';
+import type { IFileHandle, IReadStream, IWriteStream, IStats, TData, TDataOut, TMode, TTime } from './types/misc';
 import type { FsCallbackApi } from './types';
 
 export class FileHandle implements IFileHandle {
@@ -31,6 +31,14 @@ export class FileHandle implements IFileHandle {
 
   datasync(): Promise<void> {
     return promisify(this.fs, 'fdatasync')(this.fd);
+  }
+
+  createReadStream(options: opts.IFileHandleReadStreamOptions): IReadStream {
+    return this.fs.createReadStream('', { ...options, fd: this });
+  }
+
+  createWriteStream(options: opts.IFileHandleWriteStreamOptions): IWriteStream {
+    return this.fs.createWriteStream('', { ...options, fd: this });
   }
 
   readableWebStream(options?: opts.IReadableWebStreamOptions): ReadableStream {

--- a/src/node/types/misc.ts
+++ b/src/node/types/misc.ts
@@ -4,6 +4,8 @@ import type { EventEmitter } from 'events';
 import type { TSetTimeout } from '../../setTimeoutUnref';
 import type {
   IAppendFileOptions,
+  IFileHandleReadStreamOptions,
+  IFileHandleWriteStreamOptions,
   IReadableWebStreamOptions,
   IReadFileOptions,
   IStatOptions,
@@ -138,6 +140,8 @@ export interface IFileHandle {
   chmod(mode: TMode): Promise<void>;
   chown(uid: number, gid: number): Promise<void>;
   close(): Promise<void>;
+  createReadStream(options: IFileHandleReadStreamOptions): IReadStream;
+  createWriteStream(options: IFileHandleWriteStreamOptions): IWriteStream;
   datasync(): Promise<void>;
   readableWebStream(options?: IReadableWebStreamOptions): ReadableStream;
   read(buffer: Buffer | Uint8Array, offset: number, length: number, position: number): Promise<TFileHandleReadResult>;

--- a/src/node/types/options.ts
+++ b/src/node/types/options.ts
@@ -36,6 +36,26 @@ export interface IReadableWebStreamOptions {
   type?: 'bytes' | undefined;
 }
 
+export interface IFileHandleReadStreamOptions {
+  encoding?: BufferEncoding;
+  autoClose?: boolean;
+  emitClose?: boolean;
+  start?: number | undefined;
+  end?: number;
+  highWaterMark?: number;
+  flush?: boolean;
+  signal?: AbortSignal | undefined;
+}
+
+export interface IFileHandleWriteStreamOptions {
+  encoding?: BufferEncoding;
+  autoClose?: boolean;
+  emitClose?: boolean;
+  start?: number;
+  highWaterMark?: number;
+  flush?: boolean;
+}
+
 export interface IReaddirOptions extends IOptions {
   recursive?: boolean;
   withFileTypes?: boolean;


### PR DESCRIPTION
Closes #1063

Thanks for making this library! My test needed these methods to exist so I took a stab at adding support.