### PR TITLE
fix: accept passing a `FileHandle` to `createReadStream` and `createWriteStream`

### DIFF
--- a/src/__tests__/volume.test.ts
+++ b/src/__tests__/volume.test.ts
@@ -1444,4 +1444,29 @@ describe('volume', () => {
       });
     });
   });
+  describe('.createReadStream', () => {
+    it('accepts filehandle as fd option', done => {
+      const vol = Volume.fromJSON({
+        '/test.txt': 'Hello',
+      });
+      vol.promises.open('/test.txt', 'r').then(fh => {
+        const readStream = vol.createReadStream(
+          '/this/should/be/ignored',
+          { fd: fh },
+        );
+        readStream.setEncoding('utf8');
+        let readData = '';
+        readStream.on('readable', () => {
+          const chunk = readStream.read();
+          if (chunk != null) readData += chunk;
+        });
+        readStream.on('end', () => {
+          expect(readData).toEqual('Hello');
+          done();
+        });
+      }).catch((err) => {
+        expect(err).toBeNull();
+      });
+    });
+  });
 });

--- a/src/__tests__/volume.test.ts
+++ b/src/__tests__/volume.test.ts
@@ -1,3 +1,4 @@
+import { promisify } from 'util';
 import { URL } from 'url';
 import { Link } from '../node';
 import Stats from '../Stats';
@@ -1429,6 +1430,18 @@ describe('volume', () => {
     it('.vol points to current volume', () => {
       const vol = new Volume();
       expect(new StatWatcher(vol).vol).toBe(vol);
+    });
+  });
+  describe('.createWriteStream', () => {
+    it('accepts filehandle as fd option', async () => {
+      const vol = new Volume();
+      const fh = await vol.promises.open('/test.txt', 'wx', 0o600);
+      const writeStream = vol.createWriteStream('', { fd: fh });
+      await promisify(writeStream.write.bind(writeStream))(Buffer.from('Hello'));
+      await promisify(writeStream.close.bind(writeStream))();
+      expect(vol.toJSON()).toEqual({
+        '/test.txt': 'Hello',
+      });
     });
   });
 });

--- a/src/__tests__/volume.test.ts
+++ b/src/__tests__/volume.test.ts
@@ -1449,24 +1449,24 @@ describe('volume', () => {
       const vol = Volume.fromJSON({
         '/test.txt': 'Hello',
       });
-      vol.promises.open('/test.txt', 'r').then(fh => {
-        const readStream = vol.createReadStream(
-          '/this/should/be/ignored',
-          { fd: fh },
-        );
-        readStream.setEncoding('utf8');
-        let readData = '';
-        readStream.on('readable', () => {
-          const chunk = readStream.read();
-          if (chunk != null) readData += chunk;
+      vol.promises
+        .open('/test.txt', 'r')
+        .then(fh => {
+          const readStream = vol.createReadStream('/this/should/be/ignored', { fd: fh });
+          readStream.setEncoding('utf8');
+          let readData = '';
+          readStream.on('readable', () => {
+            const chunk = readStream.read();
+            if (chunk != null) readData += chunk;
+          });
+          readStream.on('end', () => {
+            expect(readData).toEqual('Hello');
+            done();
+          });
+        })
+        .catch(err => {
+          expect(err).toBeNull();
         });
-        readStream.on('end', () => {
-          expect(readData).toEqual('Hello');
-          done();
-        });
-      }).catch((err) => {
-        expect(err).toBeNull();
-      });
     });
   });
 });

--- a/src/volume.ts
+++ b/src/volume.ts
@@ -2260,7 +2260,7 @@ function FsReadStream(vol, path, options) {
   Readable.call(this, options);
 
   this.path = pathToFilename(path);
-  this.fd = options.fd === undefined ? null : options.fd;
+  this.fd = options.fd === undefined ? null : typeof options.fd !== 'number' ? options.fd.fd : options.fd;
   this.flags = options.flags === undefined ? 'r' : options.flags;
   this.mode = options.mode === undefined ? 0o666 : options.mode;
 
@@ -2429,7 +2429,7 @@ function FsWriteStream(vol, path, options) {
   Writable.call(this, options);
 
   this.path = pathToFilename(path);
-  this.fd = options.fd === undefined ? null : options.fd;
+  this.fd = options.fd === undefined ? null : typeof options.fd !== 'number' ? options.fd.fd : options.fd;
   this.flags = options.flags === undefined ? 'w' : options.flags;
   this.mode = options.mode === undefined ? 0o666 : options.mode;
 


### PR DESCRIPTION
Letting this option be a `FileHandle` aligns the API with [Node.js's `fs` module](https://nodejs.org/api/fs.html#fscreatewritestreampath-options).

(Split out from #1076 per request)