### PR TITLE
fix: don't fail on closing fd after reset has been called (#550)

### DIFF
--- a/src/__tests__/volume.test.ts
+++ b/src/__tests__/volume.test.ts
@@ -361,6 +361,23 @@ describe('volume', () => {
           '/good': 'bye',
         });
       });
+      it('Open streams should not be affected', async () => {
+        const vol = new Volume();
+        const json = {
+          '/hello': 'world',
+        };
+        vol.fromJSON(json);
+        await new Promise((resolve, reject) => {
+          vol
+            .createReadStream('/hello')
+            .on('data', () => null)
+            .on('close', resolve)
+            .on('end', () => {
+              vol.reset();
+            })
+            .on('error', reject);
+        });
+      });
     });
     describe('.openSync(path, flags[, mode])', () => {
       const vol = new Volume();


### PR DESCRIPTION
Spent a day tracking this down so I figured I could put in a fix. To review, the issue is that if you have a stream that happens to be open when you call `reset`, you get an error like this (assuming jest, but I'm sure it comes as a surprise to anyone on any testing platform):
```
> npx jest
Error: Unhandled error. (Error: EBADF: bad file descriptor, close
    at createError (/path/to/project/node_modules/memfs/src/node/util.ts:146:17)
    at Volume.getFileByFdOrThrow (/path/to/project/node_modules/memfs/src/volume.ts:540:33)
    at Volume.closeSync (/path/to/project/node_modules/memfs/src/volume.ts:818:23)
    at Immediate._onImmediate (/path/to/project/node_modules/memfs/src/volume.ts:578:25)
    at processImmediate (node:internal/timers:478:21)
    at process.topLevelDomainCallback (node:domain:160:15)
    at process.callbackTrampoline (node:internal/async_hooks:128:24) {
  code: 'EBADF'
})
    at Volume.ReadStream.emit (node:events:507:17)
    at Volume.ReadStream.emit (node:domain:488:12)
    at /path/to/project/node_modules/memfs/src/volume.ts:2397:18
    at Immediate._onImmediate (/path/to/project/node_modules/memfs/src/volume.ts:580:9)
    at processImmediate (node:internal/timers:478:21)
    at process.topLevelDomainCallback (node:domain:160:15)
    at process.callbackTrampoline (node:internal/async_hooks:128:24) {
  code: 'ERR_UNHANDLED_ERROR',
  context: Error: EBADF: bad file descriptor, close
      at createError (/path/to/project/node_modules/memfs/src/node/util.ts:146:17)
      at Volume.getFileByFdOrThrow (/path/to/project/node_modules/memfs/src/volume.ts:540:33)
      at Volume.closeSync (/path/to/project/node_modules/memfs/src/volume.ts:818:23)
      at Immediate._onImmediate (/path/to/project/node_modules/memfs/src/volume.ts:578:25)
      at processImmediate (node:internal/timers:478:21)
      at process.topLevelDomainCallback (node:domain:160:15)
      at process.callbackTrampoline (node:internal/async_hooks:128:24) {
    code: 'EBADF'
  }
}
```
I find it difficult to imagine someone calling `reset` and expecting an error when the `setImmediate` callback fires, so that's where I made my change. Other ways of fixing I thought about were:
- add a `waitForFilesToClose`, but potentially you're testing something where they wouldn't close? also it requires an extra command that you'd only use for this purpose.
- if you could somehow "reset" the actual file system, I'd imagine it would abort all the ongoing operations as well, so this seems ideologically correct (to me)