### PR TITLE
feat: support `UInt8Array` in place of `Buffer`

### DIFF
--- a/src/__tests__/volume.test.ts
+++ b/src/__tests__/volume.test.ts
@@ -390,6 +390,12 @@ describe('volume', () => {
         expect(fd).toBeGreaterThan(0);
         expect(oldMtime).not.toBe(newMtime);
       });
+      it('Create new file with Uint8Array path', () => {
+        const path = new TextEncoder().encode('/test.txt');
+        const fd = vol.openSync(path, 'w');
+        expect(typeof fd).toBe('number');
+        expect(fd).toBeGreaterThan(0);
+      });
       it('Error on file not found', () => {
         try {
           vol.openSync('/non-existing-file.txt', 'r');
@@ -404,7 +410,7 @@ describe('volume', () => {
           throw Error('This should not throw');
         } catch (err) {
           expect(err).toBeInstanceOf(TypeError);
-          expect(err.message).toBe('path must be a string or Buffer');
+          expect(err.message).toBe('path must be a string, Buffer, or Uint8Array');
         }
       });
       it('Invalid flags correct error code', () => {
@@ -477,7 +483,7 @@ describe('volume', () => {
           throw Error('This should not throw');
         } catch (err) {
           expect(err).toBeInstanceOf(TypeError);
-          expect(err.message).toBe('path must be a string or Buffer');
+          expect(err.message).toBe('path must be a string, Buffer, or Uint8Array');
           done();
         }
       });

--- a/src/__tests__/volume/__snapshots__/renameSync.test.ts.snap
+++ b/src/__tests__/volume/__snapshots__/renameSync.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`renameSync(fromPath, toPath) Throws if path is of wrong type 1`] = `"path must be a string or Buffer"`;
+exports[`renameSync(fromPath, toPath) Throws if path is of wrong type 1`] = `"path must be a string, Buffer, or Uint8Array"`;
 
-exports[`renameSync(fromPath, toPath) Throws on no params 1`] = `"path must be a string or Buffer"`;
+exports[`renameSync(fromPath, toPath) Throws on no params 1`] = `"path must be a string, Buffer, or Uint8Array"`;
 
-exports[`renameSync(fromPath, toPath) Throws on only one param 1`] = `"path must be a string or Buffer"`;
+exports[`renameSync(fromPath, toPath) Throws on only one param 1`] = `"path must be a string, Buffer, or Uint8Array"`;

--- a/src/node/constants.ts
+++ b/src/node/constants.ts
@@ -8,7 +8,7 @@ export const enum MODE {
 }
 
 export const ERRSTR = {
-  PATH_STR: 'path must be a string or Buffer',
+  PATH_STR: 'path must be a string, Buffer, or Uint8Array',
   // FD:             'file descriptor must be a unsigned 32-bit integer',
   FD: 'fd must be a file descriptor',
   MODE_INT: 'mode must be an int',

--- a/src/node/types/misc.ts
+++ b/src/node/types/misc.ts
@@ -1,4 +1,4 @@
-import type { PathLike, symlink } from 'fs';
+import type { PathLike as NodePathLike, symlink } from 'fs';
 import type { constants } from '../../constants';
 import type { EventEmitter } from 'events';
 import type { TSetTimeout } from '../../setTimeoutUnref';
@@ -13,8 +13,9 @@ import type {
 } from './options';
 import type { Readable, Writable } from 'stream';
 
-export { PathLike, symlink };
+export { symlink };
 
+export type PathLike = NodePathLike | Uint8Array; // For browser support we add Uint8Array.
 export type TDataOut = string | Buffer; // Data formats we give back to users.
 export type TEncodingExtended = BufferEncoding | 'buffer';
 export type TFileId = PathLike | number; // Number is used as a file descriptor.

--- a/src/node/util.ts
+++ b/src/node/util.ts
@@ -72,6 +72,9 @@ function getPathFromURLPosix(url): string {
 }
 
 export function pathToFilename(path: misc.PathLike): string {
+  if (path instanceof Uint8Array) {
+    path = bufferFrom(path);
+  }
   if (typeof path !== 'string' && !Buffer.isBuffer(path)) {
     try {
       if (!(path instanceof require('url').URL)) throw new TypeError(ERRSTR.PATH_STR);

--- a/src/volume.ts
+++ b/src/volume.ts
@@ -58,9 +58,9 @@ import {
   getWriteSyncArgs,
   unixify,
 } from './node/util';
-import type { PathLike, symlink } from 'fs';
+import type { symlink } from 'fs';
+import type { PathLike } from './node/types/misc';
 import type { FsPromisesApi, FsSynchronousApi } from './node/types';
-import { fsSynchronousApiList } from './node/lists/fsSynchronousApiList';
 import { Dir } from './Dir';
 
 const resolveCrossPlatform = pathModule.resolve;
@@ -1327,7 +1327,6 @@ export class Volume implements FsCallbackApi, FsSynchronousApi {
   }
 
   private realpathBase(filename: string, encoding: TEncodingExtended | undefined): TDataOut {
-    debugger;
     const realLink = this.getResolvedLinkOrThrow(filename, 'realpath');
 
     return strToEncoding(realLink.getPath() || '/', encoding);

--- a/src/volume.ts
+++ b/src/volume.ts
@@ -58,8 +58,7 @@ import {
   getWriteSyncArgs,
   unixify,
 } from './node/util';
-import type { symlink } from 'fs';
-import type { PathLike } from './node/types/misc';
+import type { PathLike, symlink } from './node/types/misc';
 import type { FsPromisesApi, FsSynchronousApi } from './node/types';
 import { Dir } from './Dir';
 


### PR DESCRIPTION
This seems reasonable, considering memfs supports the browser, and users are more likely to have instances of Uint8Array there.

Resolves https://github.com/streamich/memfs/issues/733