### PR TITLE
fix: export `Volume` class directly rather than as a `const`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import Stats from './Stats';
 import Dirent from './Dirent';
 import {
-  Volume as _Volume,
+  Volume,
   StatWatcher,
   FSWatcher,
   toUnixTimestamp,
@@ -16,13 +16,12 @@ import { fsSynchronousApiList } from './node/lists/fsSynchronousApiList';
 import { fsCallbackApiList } from './node/lists/fsCallbackApiList';
 const { F_OK, R_OK, W_OK, X_OK } = constants;
 
-export { DirectoryJSON, NestedDirectoryJSON };
-export const Volume = _Volume;
+export { DirectoryJSON, NestedDirectoryJSON, Volume };
 
 // Default volume.
-export const vol = new _Volume();
+export const vol = new Volume();
 
-export interface IFs extends _Volume {
+export interface IFs extends Volume {
   constants: typeof constants;
   Stats: new (...args) => Stats;
   Dirent: new (...args) => Dirent;
@@ -34,7 +33,7 @@ export interface IFs extends _Volume {
   _toUnixTimestamp;
 }
 
-export function createFsFromVolume(vol: _Volume): IFs {
+export function createFsFromVolume(vol: Volume): IFs {
   const fs = { F_OK, R_OK, W_OK, X_OK, constants, Stats, Dirent } as any as IFs;
 
   // Bind FS methods.
@@ -65,13 +64,13 @@ export const fs: IFs = createFsFromVolume(vol);
  * @returns A `memfs` file system instance, which is a drop-in replacement for
  *          the `fs` module.
  */
-export const memfs = (json: NestedDirectoryJSON = {}, cwd: string = '/'): { fs: IFs; vol: _Volume } => {
+export const memfs = (json: NestedDirectoryJSON = {}, cwd: string = '/'): { fs: IFs; vol: Volume } => {
   const vol = Volume.fromNestedJSON(json, cwd);
   const fs = createFsFromVolume(vol);
   return { fs, vol };
 };
 
-export type IFsWithVolume = IFs & { __vol: _Volume };
+export type IFsWithVolume = IFs & { __vol: Volume };
 
 declare let module;
 module.exports = { ...module.exports, ...fs };


### PR DESCRIPTION
This is a little fix that allows the code to work better with TS.

Currently `Volume` is re-exported as a `const` that aliases the class declaration.
This makes it very hard to use the class -- for example the following idiomatic TS code is now invalid:

```ts
import { Volume } from 'memfs';

function foo(volume: Volume) { }
//                   ^^^^^^ 'Volume' refers to a value, but is being used as a type here. Did you mean 'typeof Volume'?

// NOTE: the suggestion in the error is wrong and will not allow you to assign an instance
function bar(volume: typeof Volume) { }
bar(new Volume());
//  ^^^^^^^^^^^^ Argument of type 'Volume' is not assignable to parameter of type 'typeof Volume'.
//    Type 'Volume' is missing the following properties from type 'typeof Volume': prototype, fd
```

If we instead directly export `Volume` then TS correctly sees the re-exported type as a class declaration and everything works correctly.

Fixes #976