### PR TITLE
refactor: simplified genRndStr6 without recursion

### DIFF
--- a/src/node/util.ts
+++ b/src/node/util.ts
@@ -157,9 +157,7 @@ export function createError(errorCode: string, func = '', path = '', path2 = '',
 }
 
 export function genRndStr6(): string {
-  const str = (Math.random() + 1).toString(36).substring(2, 8);
-  if (str.length === 6) return str;
-  else return genRndStr6();
+  return Math.random().toString(36).slice(2, 8).padEnd(6, '0');
 }
 
 export function flagsToNumber(flags: misc.TFlags | undefined): number {


### PR DESCRIPTION
I slightly simplified the `genRndStr6` function by using `padEnd` for cases where the string is shorter than 6 characters. In most cases, padEnd isn’t applied, and the strings are sufficiently unique—just like in the original version.

https://gist.github.com/Connormiha/c42e57ecd1f934dea49877f5d7f815cb

By the way, package.json specifies Node >=4, but I believe that's outdated, since the project already uses `includes`, `await`, and the spread operator.