### PR TITLE
perf: remove await in loop for toSnapshot

### DIFF
--- a/src/snapshot/async.ts
+++ b/src/snapshot/async.ts
@@ -7,11 +7,12 @@ export const toSnapshot = async ({ fs, path = '/', separator = '/' }: AsyncSnaps
     const list = await fs.readdir(path);
     const entries: { [child: string]: SnapshotNode } = {};
     const dir = path.endsWith(separator) ? path : path + separator;
-    await Promise.all(
-      list.map((child) => toSnapshot({ fs, path: `${dir}${child}`, separator }).then((childSnapshot) => {
-        if (childSnapshot) entries['' + child] = childSnapshot;
-      }))
+    const snapshots = await Promise.all(
+      list.map(child => toSnapshot({ fs, path: `${dir}${child}`, separator }))
     );
+    for (let i = 0; i < list.length; i++) {
+      if (snapshots[i]) entries['' + list[i]] = snapshots[i];
+    }
     return [SnapshotNodeType.Folder, {}, entries];
   } else if (stats.isFile()) {
     const buf = (await fs.readFile(path)) as Buffer;

--- a/src/snapshot/async.ts
+++ b/src/snapshot/async.ts
@@ -7,10 +7,11 @@ export const toSnapshot = async ({ fs, path = '/', separator = '/' }: AsyncSnaps
     const list = await fs.readdir(path);
     const entries: { [child: string]: SnapshotNode } = {};
     const dir = path.endsWith(separator) ? path : path + separator;
-    for (const child of list) {
-      const childSnapshot = await toSnapshot({ fs, path: `${dir}${child}`, separator });
-      if (childSnapshot) entries['' + child] = childSnapshot;
-    }
+    await Promise.all(
+      list.map((child) => toSnapshot({ fs, path: `${dir}${child}`, separator }).then((childSnapshot) => {
+        if (childSnapshot) entries['' + child] = childSnapshot;
+      }))
+    );
     return [SnapshotNodeType.Folder, {}, entries];
   } else if (stats.isFile()) {
     const buf = (await fs.readFile(path)) as Buffer;

--- a/src/snapshot/async.ts
+++ b/src/snapshot/async.ts
@@ -7,9 +7,7 @@ export const toSnapshot = async ({ fs, path = '/', separator = '/' }: AsyncSnaps
     const list = await fs.readdir(path);
     const entries: { [child: string]: SnapshotNode } = {};
     const dir = path.endsWith(separator) ? path : path + separator;
-    const snapshots = await Promise.all(
-      list.map(child => toSnapshot({ fs, path: `${dir}${child}`, separator }))
-    );
+    const snapshots = await Promise.all(list.map(child => toSnapshot({ fs, path: `${dir}${child}`, separator })));
     for (let i = 0; i < list.length; i++) {
       if (snapshots[i]) entries['' + list[i]] = snapshots[i];
     }


### PR DESCRIPTION
This set uses await inside a loop, which means the next iteration doesn't start until the current promise is resolved. Since this is building a dictionary, it can be done in parallel to avoid blocking the next promise.