### PR TITLE
fix: Use cross-platform `dirname` instead of `posix.dirname`

### DIFF
--- a/src/core/Superblock.ts
+++ b/src/core/Superblock.ts
@@ -13,27 +13,11 @@ import type { PathLike } from '../node/types/misc';
 import { ERROR_CODE } from './constants';
 import { TFileId } from './types';
 
-type TCallback<TData> = (error?: any, data?: TData) => void;
-
 const pathSep = posix ? posix.sep : sep;
 const pathRelative = posix ? posix.relative : relative;
 const pathJoin = posix ? posix.join : join;
-const pathDirname = posix ? posix.dirname : dirname;
 
-const {
-  O_RDONLY,
-  O_WRONLY,
-  O_RDWR,
-  O_CREAT,
-  O_EXCL,
-  O_TRUNC,
-  O_APPEND,
-  O_DIRECTORY,
-  O_SYMLINK,
-  F_OK,
-  COPYFILE_EXCL,
-  COPYFILE_FICLONE_FORCE,
-} = constants;
+const { O_RDONLY, O_WRONLY, O_RDWR, O_CREAT, O_EXCL, O_TRUNC, O_APPEND, O_DIRECTORY } = constants;
 
 /**
  * Represents a filesystem superblock, which is the root of a virtual
@@ -94,8 +78,6 @@ export class Superblock {
   constructor(props = {}) {
     const root = this.createLink();
     root.setNode(this.createNode(constants.S_IFDIR | 0o777));
-
-    const self = this; // tslint:disable-line no-this-assignment
 
     root.setChild('.', root);
     root.getNode().nlink++;
@@ -487,8 +469,8 @@ export class Superblock {
       // Note that this will still throw if the ENOENT came from one of the
       // intermediate directories instead of the file itself.
       if (err.code === ERROR_CODE.ENOENT && flagsNum & O_CREAT) {
-        const dirname: string = pathDirname(filename);
-        const dirLink: Link = this.getResolvedLinkOrThrow(dirname);
+        const dirName = dirname(filename);
+        const dirLink = this.getResolvedLinkOrThrow(dirName);
         const dirNode = dirLink.getNode();
 
         // Check that the place we create the new file is actually a directory and that we are allowed to do so:
@@ -582,7 +564,7 @@ export class Superblock {
       if (err.code) err = createError(err.code, 'link', filename1, filename2);
       throw err;
     }
-    const dirname2 = pathDirname(filename2);
+    const dirname2 = dirname(filename2);
     let dir2: Link;
     try {
       dir2 = this.getLinkOrThrow(dirname2, 'link');

--- a/src/node/__tests__/volume/openSync.test.ts
+++ b/src/node/__tests__/volume/openSync.test.ts
@@ -1,4 +1,5 @@
 import { createFs } from '../../../__tests__/util';
+import { normalize, dirname } from '../../../vendor/node/path';
 
 describe('openSync(path, mode[, flags])', () => {
   it('should return a file descriptor', () => {
@@ -69,6 +70,18 @@ describe('openSync(path, mode[, flags])', () => {
           fs.openSync('/foo/bar', intent);
         }).toThrowError(/EACCES/);
       });
+    });
+
+    it('should open file when using native file seperators', () => {
+      const fs = createFs({});
+      // Normalize the path to match the current operating system's format.
+      // This is crucial for catching path-related issues that arise when using native paths on Windows.
+      const filePath = normalize('/foo/bar.txt');
+
+      fs.mkdirSync(dirname(filePath));
+      fs.writeFileSync(filePath, 'test');
+
+      expect(() => fs.openSync(filePath, 'r')).not.toThrow();
     });
   });
 });


### PR DESCRIPTION
`posix.dirname` was being used in some places, which could cause incorrect behavior on Windows systems where path separators are different. This change replaces it with the cross-platform `dirname()` to ensure consistent path handling.

This issue was introduced in commit da1388e2b5e752158246151dd095978754fcc941.

Closes #1193