### PR TITLE
feat: sort files and folder when using `toTreeSync()`

### DIFF
--- a/docs/print/index.md
+++ b/docs/print/index.md
@@ -13,14 +13,14 @@ console.log(toTreeSync(fs, { dir: process.cwd() + '/src/fsa-to-node' }));
 
 // Output:
 // src/
-// ├─ Dirent.ts
-// ├─ Stats.ts
 // ├─ __tests__/
 // │  ├─ hasBigInt.js
 // │  ├─ index.test.ts
 // │  ├─ node.test.ts
 // │  ├─ process.test.ts
-// │  ├─ promises.test.ts
+// │  └─ promises.test.ts
+// ├─ Dirent.ts
+// ├─ Stats.ts
 // ...
 ```
 
@@ -47,4 +47,22 @@ console.log(toTreeSync(fs));
 //                └─ src/
 //                   ├─ package.json
 //                   ├─ tsconfig.json
+```
+
+By default the output is sorted alphabetically with folders first, to disable sorting the `sort` option can be disabled:
+
+```
+console.log(toTreeSync(fs, { sort: false }));
+
+// Output:
+// src/
+// ├─ Dirent.ts
+// ├─ Stats.ts
+// ├─ __tests__/
+// │  ├─ hasBigInt.js
+// │  ├─ index.test.ts
+// │  ├─ node.test.ts
+// │  ├─ process.test.ts
+// │  ├─ promises.test.ts
+// ...
 ```

--- a/src/print/__tests__/index.test.ts
+++ b/src/print/__tests__/index.test.ts
@@ -19,10 +19,10 @@ test('can a one level deep directory tree', () => {
   });
   expect(toTreeSync(fs, { dir: '/' })).toMatchInlineSnapshot(`
     "/
-    ├─ file.txt
-    └─ foo/
-       ├─ bar.txt
-       └─ index.php"
+    ├─ foo/
+    │  ├─ bar.txt
+    │  └─ index.php
+    └─ file.txt"
   `);
 });
 
@@ -76,5 +76,41 @@ test('can print starting from subfolder', () => {
     ├─ c/
     │  └─ file.txt
     └─ main.rb"
+  `);
+});
+
+test('can print folders sorted first', () => {
+  const { fs } = memfs({
+    '/a.txt': '...',
+    '/b/file.txt': '...',
+    '/c.txt': '...',
+  });
+  expect(toTreeSync(fs)).toMatchInlineSnapshot(`
+    "/
+    ├─ b/
+    │  └─ file.txt
+    ├─ a.txt
+    └─ c.txt"
+  `);
+});
+
+test('can print files and folders sorted alphabetically', () => {
+  const { fs } = memfs({
+    '/a.txt': '...',
+    '/c.txt': '...',
+    '/b.txt': '...',
+    '/src/a.txt': '...',
+    '/src/c.txt': '...',
+    '/src/b.txt': '...',
+  });
+  expect(toTreeSync(fs)).toMatchInlineSnapshot(`
+    "/
+    ├─ src/
+    │  ├─ a.txt
+    │  ├─ b.txt
+    │  └─ c.txt
+    ├─ a.txt
+    ├─ b.txt
+    └─ c.txt"
   `);
 });

--- a/src/print/index.ts
+++ b/src/print/index.ts
@@ -9,9 +9,23 @@ export const toTreeSync = (fs: FsSynchronousApi, opts: ToTreeOptions = {}) => {
   if (dir[dir.length - 1] !== separator) dir += separator;
   const tab = opts.tab || '';
   const depth = opts.depth ?? 10;
+  const sort = opts.sort ?? true;
   let subtree = ' (...)';
   if (depth > 0) {
     const list = fs.readdirSync(dir, { withFileTypes: true }) as IDirent[];
+    if (sort) {
+      list.sort((a, b) => {
+        if (a.isDirectory() && b.isDirectory()) {
+          return a.name.toString().localeCompare(b.name.toString());
+        } else if (a.isDirectory()) {
+          return -1;
+        } else if (b.isDirectory()) {
+          return 1;
+        } else {
+          return a.name.toString().localeCompare(b.name.toString());
+        }
+      });
+    }
     subtree = printTree(
       tab,
       list.map(entry => tab => {
@@ -34,4 +48,5 @@ export interface ToTreeOptions {
   tab?: string;
   depth?: number;
   separator?: '/' | '\\';
+  sort?: boolean;
 }


### PR DESCRIPTION
Adds a new option `sort` to print files and folders alphabetically.

Fixes #1214