### PR TITLE
fix: add glob functions to API lists

### DIFF
--- a/src/node/lists/fsCallbackApiList.ts
+++ b/src/node/lists/fsCallbackApiList.ts
@@ -18,6 +18,7 @@ export const fsCallbackApiList: Array<keyof FsCallbackApi> = [
   'fsync',
   'ftruncate',
   'futimes',
+  'glob',
   'lchmod',
   'lchown',
   'link',

--- a/src/node/lists/fsSynchronousApiList.ts
+++ b/src/node/lists/fsSynchronousApiList.ts
@@ -15,6 +15,7 @@ export const fsSynchronousApiList: Array<keyof FsSynchronousApi> = [
   'fsyncSync',
   'ftruncateSync',
   'futimesSync',
+  'globSync',
   'lchmodSync',
   'lchownSync',
   'linkSync',


### PR DESCRIPTION
**Problem**:
The API lists seem not to have been updated when the `glob(Sync)` methods were added.
As a result `fs` instances created with `createFsFromVolume` do not have the `glob` methods available.

**Solution**:
This PR adds `glob` to the callback API list and `globSync` to sync API list.
