### PR TITLE
feat: Add FSA locking support for FileSystemSyncAccessHandle

### DIFF
--- a/src/fsa/CoreFileSystemSyncAccessHandle.ts
+++ b/src/fsa/CoreFileSystemSyncAccessHandle.ts
@@ -4,6 +4,7 @@ import { Buffer } from '../vendor/node/internal/buffer';
 import { ERROR_CODE } from '../core/constants';
 import { newNotAllowedError } from './util';
 import { FLAGS } from '../node/constants';
+import { globalLockManager } from './FileLockManager';
 
 /**
  * @see https://developer.mozilla.org/en-US/docs/Web/API/FileSystemSyncAccessHandle
@@ -16,7 +17,9 @@ export class CoreFileSystemSyncAccessHandle implements IFileSystemSyncAccessHand
     private readonly _core: Superblock,
     private readonly _path: string,
     private readonly _ctx: CoreFsaContext,
-  ) {}
+  ) {
+    globalLockManager.acquireLock(this._path);
+  }
 
   private _ensureOpen(): number {
     if (this._closed) {
@@ -39,6 +42,7 @@ export class CoreFileSystemSyncAccessHandle implements IFileSystemSyncAccessHand
       this._fd = null;
     }
     this._closed = true;
+    globalLockManager.releaseLock(this._path);
   }
 
   /**

--- a/src/fsa/FileLockManager.ts
+++ b/src/fsa/FileLockManager.ts
@@ -1,0 +1,26 @@
+export class FileLockManager {
+  private locks: Map<string, boolean> = new Map();
+
+  public acquireLock(path: string): boolean {
+    if (this.locks.get(path)) {
+      return false;
+    }
+    this.locks.set(path, true);
+    return true;
+  }
+
+  public releaseLock(path: string): void {
+    this.locks.delete(path);
+  }
+
+  public isLocked(path: string): boolean {
+    return this.locks.get(path) ?? false;
+  }
+
+  public clear(): void {
+    this.locks.clear();
+  }
+}
+
+export const globalLockManager = new FileLockManager();
+

--- a/src/fsa/index.ts
+++ b/src/fsa/index.ts
@@ -16,6 +16,7 @@ export * from './CoreFileSystemSyncAccessHandle';
 export * from './CoreFileSystemWritableFileStream';
 export * from './CoreFileSystemObserver';
 export * from './CorePermissionStatus';
+export * from './FileLockManager';
 
 /**
  * Create a new instance of an in-memory File System Access API

--- a/src/fsa/util.ts
+++ b/src/fsa/util.ts
@@ -43,3 +43,6 @@ export const newTypeMismatchError = () =>
   new DOMException('The path supplied exists, but was not an entry of requested type.', 'TypeMismatchError');
 
 export const newNotAllowedError = () => new DOMException('Permission not granted.', 'NotAllowedError');
+
+export const newNoModificationAllowedError = () =>
+  new DOMException('The file is locked and cannot be modified.', 'NoModificationAllowedError');

--- a/src/node-to-fsa/NodeFileSystemSyncAccessHandle.ts
+++ b/src/node-to-fsa/NodeFileSystemSyncAccessHandle.ts
@@ -2,6 +2,7 @@ import { assertCanWrite } from './util';
 import { Buffer } from '../vendor/node/internal/buffer';
 import type { FileSystemReadWriteOptions, IFileSystemSyncAccessHandle } from '../fsa/types';
 import type { NodeFsaContext, NodeFsaFs } from './types';
+import { globalLockManager } from '../fsa/FileLockManager';
 
 /**
  * @see https://developer.mozilla.org/en-US/docs/Web/API/FileSystemSyncAccessHandle
@@ -15,6 +16,7 @@ export class NodeFileSystemSyncAccessHandle implements IFileSystemSyncAccessHand
     protected readonly ctx: NodeFsaContext,
   ) {
     this.fd = fs.openSync(path, 'r+');
+    globalLockManager.acquireLock(this.path);
   }
 
   /**
@@ -23,6 +25,7 @@ export class NodeFileSystemSyncAccessHandle implements IFileSystemSyncAccessHand
   public async close(): Promise<void> {
     assertCanWrite(this.ctx.mode);
     this.fs.closeSync(this.fd);
+    globalLockManager.releaseLock(this.path);
   }
 
   /**

--- a/src/node-to-fsa/util.ts
+++ b/src/node-to-fsa/util.ts
@@ -43,3 +43,6 @@ export const newTypeMismatchError = () =>
   new DOMException('The path supplied exists, but was not an entry of requested type.', 'TypeMismatchError');
 
 export const newNotAllowedError = () => new DOMException('Permission not granted.', 'NotAllowedError');
+
+export const newNoModificationAllowedError = () =>
+  new DOMException('The file is locked and cannot be modified.', 'NoModificationAllowedError');


### PR DESCRIPTION
- Implements exclusive file locking for FileSystemSyncAccessHandle as per FSA spec. 
- When a sync access handle is created, it takes an exclusive lock preventing creation of additional sync handles or writable streams until closed. 
- Throws NoModificationAllowedError when async write operations are blocked by locks.

Resolves #1018 