### PR TITLE
Fix `@jsonjoy.com/fs-node` missing dependency on `@jsonjoy.com/fs-snapshot`

### DIFF
--- a/packages/fs-node/package.json
+++ b/packages/fs-node/package.json
@@ -82,6 +82,7 @@
     "@jsonjoy.com/fs-node-builtins": "workspace:*",
     "@jsonjoy.com/fs-node-utils": "workspace:*",
     "@jsonjoy.com/fs-print": "workspace:*",
+    "@jsonjoy.com/fs-snapshot": "workspace:*",
     "glob-to-regex.js": "^1.0.0",
     "thingies": "^2.5.0"
   }


### PR DESCRIPTION

Recently, our Docusaurus E2E CI started to fail on Yarn Berry with PnP linker: https://github.com/facebook/docusaurus/pull/11681

Job logs: https://github.com/facebook/docusaurus/actions/runs/21246255725/job/61136186782?pr=11681


```bash
Error:  Error: @jsonjoy.com/fs-node tried to access @jsonjoy.com/fs-snapshot, but it isn't declared in its dependencies; this makes the require call ambiguous and unsound.

Required package: @jsonjoy.com/fs-snapshot
Required by: @jsonjoy.com/fs-node@virtual:fc57f29978701b0380cf34b4829d515bc5ec75e6b58ee2fb1bd72225778da5b959326c5bab0085ce264437f5e8a4f00a12b95b40fdc82131fc496c7331e426f3#npm:4.56.9 (via /home/runner/work/docusaurus/test-website/.yarn/__virtual__/@jsonjoy.com-fs-node-virtual-9537c3ce10/4/.yarn/berry/cache/@jsonjoy.com-fs-node-npm-4.56.9-49734c8568-10c0.zip/node_modules/@jsonjoy.com/fs-node/lib/)

Require stack:
- /home/runner/work/docusaurus/test-website/.yarn/__virtual__/@jsonjoy.com-fs-node-virtual-9537c3ce10/4/.yarn/berry/cache/@jsonjoy.com-fs-node-npm-4.56.9-49734c8568-10c0.zip/node_modules/@jsonjoy.com/fs-node/lib/volume.js
```

It looks to me that volume.ts depends on fs-snapshot, so you'd rather add the dependency in package.json:

https://github.com/streamich/memfs/blob/6ff1817b82b44016252f93bf6ab9853ff98feeeb/packages/fs-node/src/volume.ts#L43