### PR TITLE
Add constructor to FsaNodeFs to avoid spread operation in constructor

### DIFF
--- a/packages/fs-fsa-to-node/src/FsaNodeFs.ts
+++ b/packages/fs-fsa-to-node/src/FsaNodeFs.ts
@@ -39,6 +39,18 @@ const noop: (...args: any[]) => any = () => {};
  * [`FileSystemDirectoryHandle` object](https://developer.mozilla.org/en-US/docs/Web/API/FileSystemDirectoryHandle).
  */
 export class FsaNodeFs extends FsaNodeCore implements FsCallbackApi, FsSynchronousApi, FsCommonObjects {
+
+  // NOTE this constructor is needed to avoid tsc from creating a contructor calling super(...arguments); leading to an assertation error in next:
+  // _assert_this_initialized.js:2 Uncaught ReferenceError: this hasn't been initialised - super() hasn't been called
+  constructor(
+    protected readonly root:
+      | fsa.IFileSystemDirectoryHandle
+      | Promise<fsa.IFileSystemDirectoryHandle>,
+    public syncAdapter?: FsaNodeSyncAdapter
+  ) {
+    super(root, syncAdapter);
+  }
+  
   // ------------------------------------------------------------ FsPromisesApi
 
   public readonly promises: FsPromisesApi = new FsPromises(this, FileHandle);


### PR DESCRIPTION
Added a constructor to FsaNodeFs to prevent assertion errors related to super() initialization.

Background: 

When i run a project using `@jsonjoy.com/fs-fsa-to-node` it works as expected in a vite env but running in a next env i see an assertation error in the console 

<img width="617" height="103" alt="Screenshot 2026-01-25 at 00 29 07" src="https://github.com/user-attachments/assets/01892e75-4992-4cf8-9650-5a75992c0045" />

Defining the constructor explicetly like:

```
  constructor(
    protected readonly root:
      | fsa.IFileSystemDirectoryHandle
      | Promise<fsa.IFileSystemDirectoryHandle>,
    public syncAdapter?: FsaNodeSyncAdapter
  ) {
    super(root, syncAdapter);
  }
```

prevents tsc from using spread on arguments in the constructor. 