### PR TITLE
fix(access): ensure symlinks are followed when checking for executable flag

### DIFF
--- a/packages/fs-node/src/__tests__/volume/access.test.ts
+++ b/packages/fs-node/src/__tests__/volume/access.test.ts
@@ -1,0 +1,104 @@
+import { create } from '../util';
+import { AMODE } from '@jsonjoy.com/fs-node-utils';
+
+const setup = () => {
+  const vol = create({ '/test.txt': 'content' });
+  vol.chmodSync('/test.txt', 0o755);
+  vol.symlinkSync('/test.txt', '/test-link');
+  return vol;
+};
+
+describe('access', () => {
+  test('F_OK follows symlink', done => {
+    const vol = setup();
+    vol.access('/test-link', AMODE.F_OK, err => {
+      try {
+        expect(err).toBeNull();
+        done();
+      } catch (failure) {
+        done(failure);
+      }
+    });
+  });
+
+  test('R_OK follows symlink to readable target', done => {
+    const vol = setup();
+    vol.access('/test-link', AMODE.R_OK, err => {
+      try {
+        expect(err).toBeNull();
+        done();
+      } catch (failure) {
+        done(failure);
+      }
+    });
+  });
+
+  test('W_OK follows symlink to writable target', done => {
+    const vol = setup();
+    vol.access('/test-link', AMODE.W_OK, err => {
+      try {
+        expect(err).toBeNull();
+        done();
+      } catch (failure) {
+        done(failure);
+      }
+    });
+  });
+
+  test('X_OK follows symlink to executable target', done => {
+    const vol = setup();
+    vol.access('/test-link', AMODE.X_OK, err => {
+      try {
+        expect(err).toBeNull();
+        done();
+      } catch (failure) {
+        done(failure);
+      }
+    });
+  });
+
+  test('R_OK through symlink to non-readable target throws EACCES', done => {
+    const vol = create({ '/secret.txt': 'nope' });
+    vol.chmodSync('/secret.txt', 0o000);
+    vol.symlinkSync('/secret.txt', '/secret-link');
+
+    vol.access('/secret-link', AMODE.R_OK, err => {
+      try {
+        expect(err).toHaveProperty('code', 'EACCES');
+        done();
+      } catch (failure) {
+        done(failure);
+      }
+    });
+  });
+
+  test('W_OK through symlink to non-writable target throws EACCES', done => {
+    const vol = create({ '/readonly.txt': 'nope' });
+    vol.chmodSync('/readonly.txt', 0o444);
+    vol.symlinkSync('/readonly.txt', '/readonly-link');
+
+    vol.access('/readonly-link', AMODE.W_OK, err => {
+      try {
+        expect(err).toHaveProperty('code', 'EACCES');
+        done();
+      } catch (failure) {
+        done(failure);
+      }
+    });
+  });
+
+  test('X_OK through symlink to non-executable target throws EACCES', done => {
+    const vol = create({ '/noexec.txt': 'nope' });
+    vol.chmodSync('/noexec.txt', 0o644);
+    vol.symlinkSync('/noexec.txt', '/noexec-link');
+
+    vol.access('/noexec-link', AMODE.X_OK, err => {
+      try {
+        expect(err).toHaveProperty('code', 'EACCES');
+        done();
+      } catch (failure) {
+        done(failure);
+      }
+    });
+  });
+});

--- a/packages/fs-node/src/__tests__/volume/accessPromise.test.ts
+++ b/packages/fs-node/src/__tests__/volume/accessPromise.test.ts
@@ -1,0 +1,55 @@
+import { create } from '../util';
+import { AMODE } from '@jsonjoy.com/fs-node-utils';
+
+const setup = () => {
+  const vol = create({ '/test.txt': 'content' });
+  vol.chmodSync('/test.txt', 0o755);
+  vol.symlinkSync('/test.txt', '/test-link');
+  return vol;
+};
+
+describe('promises.access', () => {
+  test('F_OK follows symlink', async () => {
+    const vol = setup();
+    await expect(vol.promises.access('/test-link', AMODE.F_OK)).resolves.toBeUndefined();
+  });
+
+  test('R_OK follows symlink to readable target', async () => {
+    const vol = setup();
+    await expect(vol.promises.access('/test-link', AMODE.R_OK)).resolves.toBeUndefined();
+  });
+
+  test('W_OK follows symlink to writable target', async () => {
+    const vol = setup();
+    await expect(vol.promises.access('/test-link', AMODE.W_OK)).resolves.toBeUndefined();
+  });
+
+  test('X_OK follows symlink to executable target', async () => {
+    const vol = setup();
+    await expect(vol.promises.access('/test-link', AMODE.X_OK)).resolves.toBeUndefined();
+  });
+
+  test('R_OK through symlink to non-readable target throws EACCES', async () => {
+    const vol = create({ '/secret.txt': 'nope' });
+    vol.chmodSync('/secret.txt', 0o000);
+    vol.symlinkSync('/secret.txt', '/secret-link');
+
+    await expect(vol.promises.access('/secret-link', AMODE.R_OK)).rejects.toHaveProperty('code', 'EACCES');
+  });
+
+  test('W_OK through symlink to non-writable target throws EACCES', async () => {
+    const vol = create({ '/readonly.txt': 'nope' });
+    vol.chmodSync('/readonly.txt', 0o444);
+    vol.symlinkSync('/readonly.txt', '/readonly-link');
+
+    await expect(vol.promises.access('/readonly-link', AMODE.W_OK)).rejects.toHaveProperty('code', 'EACCES');
+  });
+
+  test('X_OK through symlink to non-executable target throws EACCES', async () => {
+    const vol = create({ '/noexec.txt': 'nope' });
+    vol.chmodSync('/noexec.txt', 0o644);
+    vol.symlinkSync('/noexec.txt', '/noexec-link');
+
+    await expect(vol.promises.access('/noexec-link', AMODE.X_OK)).rejects.toHaveProperty('code', 'EACCES');
+  });
+});

--- a/packages/fs-node/src/__tests__/volume/accessSync.test.ts
+++ b/packages/fs-node/src/__tests__/volume/accessSync.test.ts
@@ -1,0 +1,55 @@
+import { create } from '../util';
+import { AMODE } from '@jsonjoy.com/fs-node-utils';
+
+const setup = () => {
+  const vol = create({ '/test.txt': 'content' });
+  vol.chmodSync('/test.txt', 0o755);
+  vol.symlinkSync('/test.txt', '/test-link');
+  return vol;
+};
+
+describe('accessSync', () => {
+  test('F_OK follows symlink', () => {
+    const vol = setup();
+    vol.accessSync('/test-link', AMODE.F_OK);
+  });
+
+  test('R_OK follows symlink to readable target', () => {
+    const vol = setup();
+    vol.accessSync('/test-link', AMODE.R_OK);
+  });
+
+  test('W_OK follows symlink to writable target', () => {
+    const vol = setup();
+    vol.accessSync('/test-link', AMODE.W_OK);
+  });
+
+  test('X_OK follows symlink to executable target', () => {
+    const vol = setup();
+    vol.accessSync('/test-link', AMODE.X_OK);
+  });
+
+  test('R_OK through symlink to non-readable target throws EACCES', () => {
+    const vol = create({ '/secret.txt': 'nope' });
+    vol.chmodSync('/secret.txt', 0o000);
+    vol.symlinkSync('/secret.txt', '/secret-link');
+
+    expect(() => vol.accessSync('/secret-link', AMODE.R_OK)).toThrow(expect.objectContaining({ code: 'EACCES' }));
+  });
+
+  test('W_OK through symlink to non-writable target throws EACCES', () => {
+    const vol = create({ '/readonly.txt': 'nope' });
+    vol.chmodSync('/readonly.txt', 0o444);
+    vol.symlinkSync('/readonly.txt', '/readonly-link');
+
+    expect(() => vol.accessSync('/readonly-link', AMODE.W_OK)).toThrow(expect.objectContaining({ code: 'EACCES' }));
+  });
+
+  test('X_OK through symlink to non-executable target throws EACCES', () => {
+    const vol = create({ '/noexec.txt': 'nope' });
+    vol.chmodSync('/noexec.txt', 0o644);
+    vol.symlinkSync('/noexec.txt', '/noexec-link');
+
+    expect(() => vol.accessSync('/noexec-link', AMODE.X_OK)).toThrow(expect.objectContaining({ code: 'EACCES' }));
+  });
+});

--- a/packages/fs-node/src/volume.ts
+++ b/packages/fs-node/src/volume.ts
@@ -928,7 +928,7 @@ export class Volume implements FsCallbackApi, FsSynchronousApi {
   };
 
   private _access(filename: string, mode: number) {
-    const link = this._core.getLinkOrThrow(filename, 'access');
+    const link = this._core.getResolvedLinkOrThrow(filename, 'access');
     const node = link.getNode();
 
     // F_OK (0) just checks for existence, which we already confirmed above


### PR DESCRIPTION
This is a one-line change in `volume.ts` which always resolves paths in the inner `_access` implementation.

The result is that executable symlinks are now detected properly by `access()`, `accessSync()` and `promises.access()`.

Added test suites for each of APIs asserting as much.

Fixes #1252
