### PR TITLE
fix: uncomment cpSync and statfsSync in fsSynchronousApiList

### DIFF
--- a/packages/fs-node-utils/src/lists/fsSynchronousApiList.ts
+++ b/packages/fs-node-utils/src/lists/fsSynchronousApiList.ts
@@ -7,6 +7,7 @@ export const fsSynchronousApiList: Array<keyof FsSynchronousApi> = [
   'chownSync',
   'closeSync',
   'copyFileSync',
+  'cpSync',
   'existsSync',
   'fchmodSync',
   'fchownSync',
@@ -33,6 +34,7 @@ export const fsSynchronousApiList: Array<keyof FsSynchronousApi> = [
   'renameSync',
   'rmdirSync',
   'rmSync',
+  'statfsSync',
   'statSync',
   'symlinkSync',
   'truncateSync',
@@ -42,7 +44,4 @@ export const fsSynchronousApiList: Array<keyof FsSynchronousApi> = [
   'writeFileSync',
   'writeSync',
   'writevSync',
-
-  // 'cpSync',
-  // 'statfsSync',
 ];

--- a/packages/fs-node/src/lists/fsSynchronousApiList.ts
+++ b/packages/fs-node/src/lists/fsSynchronousApiList.ts
@@ -7,6 +7,7 @@ export const fsSynchronousApiList: Array<keyof FsSynchronousApi> = [
   'chownSync',
   'closeSync',
   'copyFileSync',
+  'cpSync',
   'existsSync',
   'fchmodSync',
   'fchownSync',
@@ -33,6 +34,7 @@ export const fsSynchronousApiList: Array<keyof FsSynchronousApi> = [
   'renameSync',
   'rmdirSync',
   'rmSync',
+  'statfsSync',
   'statSync',
   'symlinkSync',
   'truncateSync',
@@ -42,7 +44,4 @@ export const fsSynchronousApiList: Array<keyof FsSynchronousApi> = [
   'writeFileSync',
   'writeSync',
   'writevSync',
-
-  // 'cpSync',
-  // 'statfsSync',
 ];


### PR DESCRIPTION
https://github.com/streamich/memfs/blob/74c356096bd1458675fd2028d2b07d1f2de6db67/packages/memfs/src/index.ts#L40-L42

The `createFsFromVolume` function relies on this list to add various methods to the `fs` object, and both `cpSync` and `statfsSync` have been implemented; they should be uncommented to be properly added to the `fs` object.