### PR TITLE
fix: clamp negative truncate length to zero (uninitialized-memory leak)

### DIFF
--- a/packages/fs-core/src/Node.ts
+++ b/packages/fs-core/src/Node.ts
@@ -222,7 +222,12 @@ export class Node {
   }
 
   truncate(len: number = 0) {
-    if (!len) {
+    // A negative length is clamped to zero, matching Node.js `fs.truncate`,
+    // which truncates to an empty file rather than producing a negative size.
+    // Without this, `this.size` becomes negative and `getBuffer()`'s
+    // `subarray(0, this.size)` reads past the used region, exposing
+    // uninitialized heap memory from the unsafe-allocated backing buffer.
+    if (len <= 0) {
       this.buf = EMPTY_BUFFER;
       this.capacity = 0;
       this.size = 0;

--- a/packages/fs-core/src/__tests__/Node.test.ts
+++ b/packages/fs-core/src/__tests__/Node.test.ts
@@ -72,6 +72,18 @@ describe('Node', () => {
       expect(node.getBuffer().length).toBe(0);
     });
 
+    it('should clamp a negative truncate length to zero (matches Node.js)', () => {
+      const node = new Node(1, 0o666);
+      node.write(bufferFrom('hello'), 0, 5, 0);
+      expect(node.getSize()).toBe(5);
+      node.truncate(-1);
+      // Node.js `fs.truncate(path, -1)` produces an empty file rather than a
+      // negative size; previously this left `size === -1`, and `getBuffer()`
+      // leaked uninitialized heap memory via `subarray(0, -1)`.
+      expect(node.getSize()).toBe(0);
+      expect(node.getBuffer().length).toBe(0);
+    });
+
     it('should handle read from various positions', () => {
       const node = new Node(1, 0o666);
       node.write(bufferFrom('hello world'), 0, 11, 0);

--- a/packages/fs-node/src/__tests__/volume.test.ts
+++ b/packages/fs-node/src/__tests__/volume.test.ts
@@ -1230,6 +1230,16 @@ describe('volume', () => {
         vol.truncateSync('/2', 10);
         expect(vol.readFileSync('/2', 'utf8')).toBe('12345\0\0\0\0\0');
       });
+      it('Negative length truncates to empty (matches Node.js, no memory leak)', () => {
+        const fd = vol.openSync('/neg', 'w');
+        vol.writeFileSync(fd, '12345');
+        expect(vol.readFileSync('/neg', 'utf8')).toBe('12345');
+        vol.truncateSync('/neg', -1);
+        // Node.js truncates to an empty file for negative lengths. Previously
+        // memfs left a negative size and leaked uninitialized heap bytes.
+        expect(vol.readFileSync('/neg').length).toBe(0);
+        expect(vol.readFileSync('/neg', 'utf8')).toBe('');
+      });
     });
     describe('.truncate(path[, len], callback)', () => {
       xit('...', () => {});


### PR DESCRIPTION
## Problem

`Node.truncate(len)` (in `fs-core`) only special-cases `len === 0`. A **negative** length falls through to the `if (len <= this.size)` branch and sets `this.size` to the negative value:

```ts
truncate(len: number = 0) {
  if (!len) { /* empty file */ return; }   // only len === 0
  if (len <= this.size) this.size = len;    // -1 <= 5  →  size = -1
  ...
}
```

`getBuffer()` then does `this.buf.subarray(0, this.size)`. With `this.size === -1`, `subarray` treats the end index relative to the buffer's length and returns bytes **past the used region** — i.e. uninitialized memory from the `bufferAllocUnsafe` backing buffer.

### Reproduction

```ts
import { Volume } from 'memfs';

const vol = new Volume();
vol.writeFileSync('/a', 'hello');
vol.truncateSync('/a', -1);

vol.readFileSync('/a').length;            // 63  (!!)  — expected 0
vol.readFileSync('/a').toString('hex');   // 68656c6c6f<uninitialized heap bytes…>
```

Node.js for comparison:

```js
fs.truncateSync(file, -1);   // file is now 0 bytes
fs.ftruncateSync(fd, -100);  // 0 bytes
```

Node's `fs.truncate` / `fs.ftruncate` clamp a negative length to an empty file (the C++ layer floors negative offsets at 0). memfs instead produced a *larger* file leaking adjacent heap contents.

## Fix

Treat a negative `len` the same as `0` in `Node.truncate` — change the `len === 0` guard to `len <= 0`. One-line behavioral change; `len === 0` is unaffected.

## Tests

Regression tests added at two levels, both verified to **fail before** the fix and **pass after**:

- `fs-core` unit: `Node#truncate(-1)` → size `0`, empty buffer.
- `fs-node` public API: `vol.truncateSync('/neg', -1)` → `readFileSync(...).length === 0` (guards against the leak).

Full `fs-core` + `fs-node` suites pass (817 tests), `typecheck` and `prettier:check` clean.

## Context

While investigating #942 (close-after-unlink — already resolved by the `Superblock` refactor), differential testing against Node's real `fs` surfaced this separate negative-length truncate parity gap, which has the added concern of exposing uninitialized memory.