### PR TITLE
chore: remove tslib from peerDependencies

### DIFF
--- a/packages/memfs/package.json
+++ b/packages/memfs/package.json
@@ -124,9 +124,6 @@
     "webpack-cli": "^5.1.4",
     "webpack-dev-server": "^4.15.1"
   },
-  "peerDependencies": {
-    "tslib": "2"
-  },
   "dependencies": {
     "@jsonjoy.com/fs-core": "workspace:*",
     "@jsonjoy.com/fs-fsa": "workspace:*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4976,8 +4976,6 @@ __metadata:
     webpack: "npm:^5.87.0"
     webpack-cli: "npm:^5.1.4"
     webpack-dev-server: "npm:^4.15.1"
-  peerDependencies:
-    tslib: 2
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Summary

Fixes #1241

`packages/memfs/package.json` lists `tslib` both as a production dependency (`"^2.0.0"`) and as a peer dependency (`"2"`). As reported in #1241, this causes pnpm to emit an unmet/missing peer dependency warning in consuming projects that don't declare `tslib` themselves, even though memfs already resolves it through its own `dependencies`.

Per the maintainer's guidance on the issue:

> Probably should be just `"^2.0.0"` in `"dependencies"`. Not in `"peerDependencies"`.

## Change

Removes the `peerDependencies` entry for `tslib`, keeping `"tslib": "^2.0.0"` in `dependencies`. Package-manifest-only change; no runtime code is touched.
