### PR TITLE
fix(fs-node): resolve drive-letter file: URLs like Node's fileURLToPath

### DIFF
--- a/packages/fs-node/src/__tests__/volume.test.ts
+++ b/packages/fs-node/src/__tests__/volume.test.ts
@@ -638,6 +638,17 @@ describe('volume', () => {
         const str = vol.readFileSync(new URL('file:///text.txt')).toString();
         expect(str).toBe(data);
       });
+      it('Read file with a drive-letter file: URL (issue #1098)', () => {
+        // `pathToFileURL` on Windows produces URLs such as
+        // `file:///C:/src/file.txt`. Node's `fs` strips the leading slash
+        // before the drive letter, so the URL resolves to the same file as the
+        // equivalent string path. memfs must do the same instead of looking up
+        // `/C:/src/file.txt`, which throws ENOENT.
+        const driveVol = new Volume();
+        driveVol.fromJSON({ 'C:/src/file.txt': 'Hello from fake file!' });
+        const url = new URL('file:///C:/src/file.txt');
+        expect(driveVol.readFileSync(url, 'utf8')).toBe('Hello from fake file!');
+      });
       it('Specify encoding as string', () => {
         const str = vol.readFileSync('/text.txt', 'utf8');
         expect(str).toBe(data);

--- a/packages/fs-node/src/util.ts
+++ b/packages/fs-node/src/util.ts
@@ -64,7 +64,14 @@ function getPathFromURLPosix(url): string {
       }
     }
   }
-  return decodeURIComponent(pathname);
+  const filepath = decodeURIComponent(pathname);
+  // `pathToFileURL` on Windows produces URLs with a leading slash before the
+  // drive letter (e.g. `file:///C:/dir` -> pathname `/C:/dir`). Node's
+  // `fileURLToPath` strips that slash so the value matches the string path
+  // form (`C:/dir`), which is how memfs represents the same location
+  // internally. Do the same here so drive-letter `file:` URLs resolve instead
+  // of throwing ENOENT. POSIX URLs (no drive letter) are left untouched.
+  return filepath.replace(/^\/([a-zA-Z]:)/, '$1');
 }
 
 export function pathToFilename(path: misc.PathLike): string {


### PR DESCRIPTION
## Problem

`readFile` (and the other fs-node APIs) fail on Windows-style `file:` URLs with a drive letter: a `URL` like `file:///C:/foo/bar.txt` resolves to the malformed path `/C:/foo/bar.txt` instead of `C:/foo/bar.txt`, so the file is never found. Node's own `fs` handles this via `fileURLToPath` semantics.

Closes #1098

## Fix

`pathToFilename`'s URL branch in `packages/fs-node/src/util.ts` now strips the leading slash when the URL pathname carries a Windows drive letter, matching Node's `fileURLToPath` behavior for drive-letter paths while leaving POSIX `file:` URLs untouched.

## Testing

New regression test in `packages/fs-node/src/__tests__/volume.test.ts` ("Read file with a drive-letter file: URL"). Suite result: 177 passed, 13 skipped.
