### PR TITLE
test(fs-node): cover FileHandle close after unlink

### DIFF
--- a/packages/fs-node/src/__tests__/volume/FileHandle.test.ts
+++ b/packages/fs-node/src/__tests__/volume/FileHandle.test.ts
@@ -403,6 +403,15 @@ describe('FileHandle', () => {
       // Third close should resolve immediately
       await handle.close();
     });
+
+    it('allows closing a handle after its path has been unlinked', async () => {
+      const fs = createFs({});
+      const handle = await fs.promises.open('/test', 'w');
+
+      await fs.promises.unlink('/test');
+
+      await expect(handle.close()).resolves.toBeUndefined();
+    });
   });
 
   describe('createReadStream()', () => {


### PR DESCRIPTION
## Summary
- add regression coverage for closing a `FileHandle` after its path has been unlinked

## Tests
- `yarn jest packages/fs-node/src/__tests__/volume/FileHandle.test.ts --runInBand`
- `yarn workspace @jsonjoy.com/fs-node typecheck`