### PR TITLE
feat: persist git-fsa directory handle

### DIFF
--- a/packages/memfs/demo/git-fsa/README.md
+++ b/packages/memfs/demo/git-fsa/README.md
@@ -1,18 +1,39 @@
-This demo showcase how to run Git in browser but write to a real user file system
-folder. It is possible through File System Access API. The API allows to request
-a folder from user and then use it as a real file system in browser.
+# Git in a real browser folder
 
-In this demo we use `memfs` to create a Node `fs`-like file system in browser
-out of the folder provided by File System Access API. We then use `isomorphic-git`
-to run Git commands on that file system.
+This demo shows how to run Git in a browser while writing to a real folder on
+the user's device. It uses the File System Access API to select a folder,
+`memfs` to expose that folder through a Node.js `fs`-like API, and
+`isomorphic-git` to run Git commands.
 
-In the demo itself we initiate a Git repo, then we create a `README.md` file, we
-stage it, and finally we commit it.
+The first time a folder is selected, the demo creates a repository in its
+`repo` subdirectory, writes and stages a `README.md`, and creates an initial
+commit. The selected directory handle is saved in IndexedDB. On later visits,
+the demo reopens the repository or asks the user to restore permission with a
+button click.
 
 https://github.com/streamich/memfs/assets/9773803/c15212e8-3ee2-4d2a-b325-9fbdcc377c12
 
-Run:
+## Run
+
+From the repository root:
 
 ```
-yarn demo:git-fsa
+yarn build
+yarn workspace memfs demo:git-fsa
 ```
+
+Open `http://localhost:9876` in Chrome or Edge. Browsers treat localhost as a
+secure context for the File System Access API.
+
+## Manual test
+
+1. Select a new empty folder and confirm that it receives `repo/README.md` and
+   a `repo/.git` directory.
+2. Reload the page. If the browser asks for permission again, click
+   **Reconnect saved folder** and grant read/write access.
+3. Confirm that the page reports that it reopened the repository and that no
+   second repository or initial commit is created.
+4. Deny a reconnect request and confirm that the page reports the denial
+   without changing the folder.
+5. Click **Forget saved folder**, reload, and confirm that the page asks for a
+   new folder.

--- a/packages/memfs/demo/git-fsa/handle-store.ts
+++ b/packages/memfs/demo/git-fsa/handle-store.ts
@@ -1,0 +1,47 @@
+const DATABASE_NAME = 'memfs-git-fsa';
+const DATABASE_VERSION = 1;
+const STORE_NAME = 'handles';
+const ROOT_HANDLE_KEY = 'root';
+
+const openDatabase = (): Promise<IDBDatabase> =>
+  new Promise((resolve, reject) => {
+    const request = indexedDB.open(DATABASE_NAME, DATABASE_VERSION);
+    request.onupgradeneeded = () => {
+      if (!request.result.objectStoreNames.contains(STORE_NAME)) request.result.createObjectStore(STORE_NAME);
+    };
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+
+const runTransaction = async <T>(
+  mode: IDBTransactionMode,
+  createRequest: (store: IDBObjectStore) => IDBRequest<T>,
+): Promise<T> => {
+  const database = await openDatabase();
+  try {
+    return await new Promise<T>((resolve, reject) => {
+      const transaction = database.transaction(STORE_NAME, mode);
+      const request = createRequest(transaction.objectStore(STORE_NAME));
+      let result: T;
+      request.onsuccess = () => {
+        result = request.result;
+      };
+      transaction.oncomplete = () => resolve(result);
+      transaction.onerror = () => reject(transaction.error);
+      transaction.onabort = () => reject(transaction.error);
+    });
+  } finally {
+    database.close();
+  }
+};
+
+export const saveDirectoryHandle = async (handle: FileSystemDirectoryHandle): Promise<void> => {
+  await runTransaction('readwrite', store => store.put(handle, ROOT_HANDLE_KEY));
+};
+
+export const loadDirectoryHandle = async (): Promise<FileSystemDirectoryHandle | undefined> =>
+  await runTransaction('readonly', store => store.get(ROOT_HANDLE_KEY));
+
+export const clearDirectoryHandle = async (): Promise<void> => {
+  await runTransaction('readwrite', store => store.delete(ROOT_HANDLE_KEY));
+};

--- a/packages/memfs/demo/git-fsa/main.ts
+++ b/packages/memfs/demo/git-fsa/main.ts
@@ -2,47 +2,185 @@
 (window as any).Buffer = require('buffer').Buffer;
 
 import { FsaNodeFs } from '../../src/fsa-to-node';
-import type * as fsa from '../../src/fsa/types';
-
+import type { IFileSystemDirectoryHandle } from '../../src/fsa';
 import git from 'isomorphic-git';
+import { clearDirectoryHandle, loadDirectoryHandle, saveDirectoryHandle } from './handle-store';
 
-const demo = async (dir: fsa.IFileSystemDirectoryHandle) => {
+const REPO_DIR = '/repo';
+const PERMISSION = { mode: 'readwrite' } as const;
+
+type BrowserDirectoryHandle = FileSystemDirectoryHandle & {
+  queryPermission(descriptor: typeof PERMISSION): Promise<PermissionState>;
+  requestPermission(descriptor: typeof PERMISSION): Promise<PermissionState>;
+};
+
+type DemoWindow = Window & {
+  fs?: FsaNodeFs;
+  showDirectoryPicker?: (options: { id: string; mode: 'readwrite' }) => Promise<BrowserDirectoryHandle>;
+};
+
+const demoWindow = window as DemoWindow;
+
+const isMissing = (error: unknown): boolean =>
+  !!error &&
+  typeof error === 'object' &&
+  ('code' in error ? error.code === 'ENOENT' : 'name' in error && error.name === 'NotFoundError');
+
+const hasRepository = async (fs: FsaNodeFs): Promise<boolean> => {
   try {
-    const fs = ((<any>window).fs = new FsaNodeFs(dir));
-
-    console.log('Create "/repo" folder');
-    await fs.promises.mkdir('/repo');
-
-    console.log('Init git repo');
-    await git.init({ fs, dir: 'repo' });
-
-    console.log('Create README file');
-    await fs.promises.writeFile('/repo/README.md', 'Hello World\n');
-
-    console.log('Stage README file');
-    await git.add({ fs, dir: '/repo', filepath: 'README.md' });
-
-    console.log('Commit README file');
-    await git.commit({
-      fs,
-      dir: '/repo',
-      author: { name: 'Git', email: 'leonid@kingdom.com' },
-      message: 'fea: initial commit',
-    });
+    return (await fs.promises.stat(`${REPO_DIR}/.git`)).isDirectory();
   } catch (error) {
-    console.log(error);
-    console.log((<any>error).name);
+    if (isMissing(error)) return false;
+    throw error;
   }
 };
 
-const main = async () => {
-  const button = document.createElement('button');
-  button.textContent = 'Select an empty folder';
-  document.body.appendChild(button);
-  button.onclick = async () => {
-    const dir = await (window as any).showDirectoryPicker({ id: 'demo', mode: 'readwrite' });
-    await demo(dir);
+const createRepository = async (fs: FsaNodeFs): Promise<void> => {
+  console.log(`Create "${REPO_DIR}" folder`);
+  await fs.promises.mkdir(REPO_DIR, { recursive: true });
+
+  console.log('Init git repo');
+  await git.init({ fs, dir: REPO_DIR });
+
+  console.log('Create README file');
+  await fs.promises.writeFile(`${REPO_DIR}/README.md`, 'Hello World\n');
+
+  console.log('Stage README file');
+  await git.add({ fs, dir: REPO_DIR, filepath: 'README.md' });
+
+  console.log('Commit README file');
+  await git.commit({
+    fs,
+    dir: REPO_DIR,
+    author: { name: 'Git', email: 'leonid@kingdom.com' },
+    message: 'fea: initial commit',
+  });
+};
+
+const openDirectory = async (handle: BrowserDirectoryHandle): Promise<'created' | 'reopened'> => {
+  const root = handle as unknown as IFileSystemDirectoryHandle;
+  const fs = (demoWindow.fs = new FsaNodeFs(root));
+  if (!(await hasRepository(fs))) {
+    await createRepository(fs);
+    return 'created';
+  }
+  const [latestCommit] = await git.log({ fs, dir: REPO_DIR, depth: 1 });
+  console.log(`Reopened "${handle.name}" at commit ${latestCommit.oid}`);
+  return 'reopened';
+};
+
+const errorMessage = (error: unknown): string => (error instanceof Error ? error.message : String(error));
+
+const isAbort = (error: unknown): boolean =>
+  !!error && typeof error === 'object' && 'name' in error && error.name === 'AbortError';
+
+const main = async (): Promise<void> => {
+  const heading = document.createElement('h1');
+  heading.textContent = 'Git in a real folder';
+  const status = document.createElement('p');
+  const selectButton = document.createElement('button');
+  selectButton.textContent = 'Select an empty folder';
+  const reconnectButton = document.createElement('button');
+  reconnectButton.textContent = 'Reconnect saved folder';
+  reconnectButton.hidden = true;
+  const forgetButton = document.createElement('button');
+  forgetButton.textContent = 'Forget saved folder';
+  forgetButton.hidden = true;
+  document.body.append(heading, status, selectButton, reconnectButton, forgetButton);
+
+  let savedHandle: BrowserDirectoryHandle | undefined;
+
+  const setBusy = (busy: boolean): void => {
+    selectButton.disabled = busy;
+    reconnectButton.disabled = busy;
+    forgetButton.disabled = busy;
   };
+
+  const showOpened = (handle: BrowserDirectoryHandle, result: 'created' | 'reopened'): void => {
+    status.textContent =
+      result === 'created'
+        ? `Created the demo repository in "${handle.name}".`
+        : `Reopened the demo repository in "${handle.name}".`;
+    reconnectButton.hidden = true;
+    forgetButton.hidden = false;
+  };
+
+  const activate = async (handle: BrowserDirectoryHandle): Promise<void> => {
+    showOpened(handle, await openDirectory(handle));
+  };
+
+  selectButton.onclick = async () => {
+    if (!demoWindow.showDirectoryPicker) return;
+    setBusy(true);
+    try {
+      const handle = await demoWindow.showDirectoryPicker({ id: 'git-fsa-demo', mode: 'readwrite' });
+      await activate(handle);
+      await saveDirectoryHandle(handle);
+      savedHandle = handle;
+    } catch (error) {
+      if (!isAbort(error)) status.textContent = `Could not open the folder: ${errorMessage(error)}`;
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  reconnectButton.onclick = async () => {
+    if (!savedHandle) return;
+    setBusy(true);
+    try {
+      if ((await savedHandle.requestPermission(PERMISSION)) === 'granted') await activate(savedHandle);
+      else status.textContent = `Permission was not granted for "${savedHandle.name}".`;
+    } catch (error) {
+      status.textContent = `Could not reconnect the folder: ${errorMessage(error)}`;
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  forgetButton.onclick = async () => {
+    setBusy(true);
+    try {
+      await clearDirectoryHandle();
+      savedHandle = undefined;
+      delete demoWindow.fs;
+      status.textContent = 'Forgot the saved folder.';
+      reconnectButton.hidden = true;
+      forgetButton.hidden = true;
+    } catch (error) {
+      status.textContent = `Could not forget the folder: ${errorMessage(error)}`;
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  if (!demoWindow.showDirectoryPicker) {
+    selectButton.disabled = true;
+    status.textContent = 'This browser does not support the File System Access API.';
+    return;
+  }
+
+  try {
+    savedHandle = (await loadDirectoryHandle()) as BrowserDirectoryHandle | undefined;
+    if (!savedHandle) {
+      status.textContent = 'Select an empty folder to create the demo repository.';
+      return;
+    }
+    forgetButton.hidden = false;
+    if ((await savedHandle.queryPermission(PERMISSION)) === 'granted') {
+      setBusy(true);
+      try {
+        await activate(savedHandle);
+      } finally {
+        setBusy(false);
+      }
+    } else {
+      status.textContent = `Reconnect "${savedHandle.name}" to continue.`;
+      reconnectButton.hidden = false;
+    }
+  } catch (error) {
+    status.textContent = `Could not restore the saved folder: ${errorMessage(error)}`;
+    reconnectButton.hidden = !savedHandle;
+  }
 };
 
 main();

--- a/packages/memfs/demo/git-fsa/webpack.config.js
+++ b/packages/memfs/demo/git-fsa/webpack.config.js
@@ -1,17 +1,20 @@
 const path = require('path');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const root = require('app-root-path');
+const webpack = require('webpack');
 
 module.exports = {
   mode: 'development',
   devtool: 'inline-source-map',
   entry: {
     bundle: __dirname + '/main',
-    worker: __dirname + '/worker',
   },
   plugins: [
+    new webpack.NormalModuleReplacementPlugin(/^node:/, resource => {
+      resource.request = resource.request.slice(5);
+    }),
     new HtmlWebpackPlugin({
-      title: 'Development',
+      title: 'Git in a real folder',
     }),
   ],
   module: {
@@ -27,11 +30,12 @@ module.exports = {
     extensions: ['.tsx', '.ts', '.js'],
     fallback: {
       assert: require.resolve('assert'),
-      buffer: require.resolve('buffer'),
+      buffer: require.resolve('buffer/'),
+      events: require.resolve('events/'),
       path: require.resolve('path-browserify'),
       process: require.resolve('process/browser'),
       stream: require.resolve('readable-stream'),
-      url: require.resolve('url'),
+      url: require.resolve('url/'),
       util: require.resolve('util'),
     },
   },
@@ -43,13 +47,6 @@ module.exports = {
     path: path.resolve(root.path, 'dist'),
   },
   devServer: {
-    // HTTPS is required for SharedArrayBuffer to work.
-    https: true,
-    headers: {
-      // These two headers are required for SharedArrayBuffer to work.
-      'Cross-Origin-Opener-Policy': 'same-origin',
-      'Cross-Origin-Embedder-Policy': 'require-corp',
-    },
     port: 9876,
     hot: false,
   },

--- a/packages/memfs/demo/git-fsa/worker.ts
+++ b/packages/memfs/demo/git-fsa/worker.ts
@@ -1,9 +1,0 @@
-(self as any).process = require('process/browser');
-(self as any).Buffer = require('buffer').Buffer;
-
-import { FsaNodeSyncWorker } from '../../src/fsa-to-node/worker/FsaNodeSyncWorker';
-
-if (typeof window === 'undefined') {
-  const worker = new FsaNodeSyncWorker();
-  worker.start();
-}

--- a/packages/memfs/package.json
+++ b/packages/memfs/package.json
@@ -102,6 +102,7 @@
     "app-root-path": "^3.1.0",
     "assert": "^2.0.0",
     "buffer": "^6.0.3",
+    "events": "^3.3.0",
     "html-webpack-plugin": "^5.5.3",
     "husky": "^8.0.1",
     "isomorphic-git": "^1.24.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4951,6 +4951,7 @@ __metadata:
     app-root-path: "npm:^3.1.0"
     assert: "npm:^2.0.0"
     buffer: "npm:^6.0.3"
+    events: "npm:^3.3.0"
     glob-to-regex.js: "npm:^1.0.1"
     html-webpack-plugin: "npm:^5.5.3"
     husky: "npm:^8.0.1"


### PR DESCRIPTION
## Summary

Update the browser Git + File System Access demo so it can remember and reopen the selected folder.

This pattern is useful for browser-based Git clients, editors, IDEs, local-first apps, and content tools that work directly with user folders. Those products can resume the same folder after a reload instead of asking users to select it again or accidentally initializing the demo repository twice.

## What changed

- Store the selected directory handle in IndexedDB.
- Restore access automatically when permission remains granted.
- Provide reconnect and forget actions when permission must be restored.
- Reopen an existing demo repository without creating another initial commit.
- Repair the demo's browser build after the monorepo migration and remove its unused worker.
- Document the run command and manual test flow.

## Why

The existing demo was a one-time flow: it forgot the selected folder on reload and always tried to create a new `/repo` directory. Its browser build also referenced an old worker path and did not handle the `node:` imports used by the current workspace packages.

## Testing

- `yarn test` — 87 suites and 1,244 tests passed
- `yarn typecheck`
- `yarn prettier:check`
- `yarn build`
- `yarn workspace memfs webpack --config ./demo/git-fsa/webpack.config.js`
- Manually created the demo repository, reloaded the page, reopened the saved folder, and verified that only one initial commit existed
