### PR TITLE
fix(build): embed sources in published sourcemaps

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     "noImplicitAny": false,
     "strictNullChecks": true,
     "sourceMap": true,
+    "inlineSources": true,
     "outDir": "lib",
     "declaration": true,
     "skipLibCheck": true,


### PR DESCRIPTION
## Summary

Fixes #1258.

TypeScript emits JavaScript sourcemaps with references to `src/**/*.ts`, but the published packages only include `lib`. Because `sourcesContent` was not embedded, tools such as Vite could not hydrate the referenced sources and reported missing-source warnings.

Enable `inlineSources` in the shared TypeScript configuration so all package builds embed their source content in published sourcemaps.

## Validation

- `yarn build`
- Verified all 81 generated `lib/**/*.js.map` files contain `sourcesContent`
- `yarn workspace memfs exec jest --runInBand`
- `yarn prettier:check`
