### PR TITLE
fix(fs-node): match Node directory iteration lifecycle

### DIFF
--- a/packages/fs-node/src/Dir.ts
+++ b/packages/fs-node/src/Dir.ts
@@ -27,6 +27,7 @@ export class Dir implements IDir {
   }
 
   private readBase(iteratorInfo: IterableIterator<[string, Link | undefined]>[]): IDirent | null {
+    if (iteratorInfo.length === 0) return null;
     let done: boolean | undefined;
     let value: [string, Link | undefined];
     let name: string;
@@ -177,32 +178,23 @@ export class Dir implements IDir {
     return this.readBase(this.iteratorInfo);
   }
 
-  [Symbol.asyncIterator](): AsyncIterableIterator<IDirent> {
-    return {
-      next: async () => {
-        try {
-          const dirEnt = await this.read();
-
-          if (dirEnt !== null) {
-            return { done: false, value: dirEnt };
-          } else {
-            return { done: true, value: undefined };
-          }
-        } catch (err) {
-          throw err;
-        }
-      },
-      [Symbol.asyncIterator](): AsyncIterableIterator<IDirent> {
-        return this;
-      },
-    };
+  async *[Symbol.asyncIterator](): AsyncIterableIterator<IDirent> {
+    try {
+      while (true) {
+        const dirEnt = await this.read();
+        if (dirEnt === null) break;
+        yield dirEnt;
+      }
+    } finally {
+      await this.close();
+    }
   }
 
-  [Symbol.asyncDispose](): Promise<void> {
-    return this.close();
+  async [Symbol.asyncDispose](): Promise<void> {
+    if (!this.closed) await this.close();
   }
 
   [Symbol.dispose](): void {
-    this.closeSync();
+    if (!this.closed) this.closeSync();
   }
 }

--- a/packages/fs-node/src/__tests__/Dir.lifecycle.test.ts
+++ b/packages/fs-node/src/__tests__/Dir.lifecycle.test.ts
@@ -1,0 +1,57 @@
+import * as fs from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { Volume } from '../volume';
+
+describe.each(['node', 'memfs'])('Dir lifecycle (%s)', backend => {
+  let path: string;
+  let vol: Volume;
+  const open = () => (backend === 'node' ? fs.opendirSync(path) : vol.opendirSync(path));
+  beforeEach(() => {
+    if (backend === 'node') {
+      path = fs.mkdtempSync(join(tmpdir(), 'memfs-dir-'));
+      fs.writeFileSync(join(path, 'file'), 'content');
+    } else {
+      path = '/dir';
+      vol = Volume.fromJSON({ '/dir/file': 'content' });
+    }
+  });
+  afterEach(() => {
+    if (backend === 'node') fs.rmSync(path, { recursive: true });
+  });
+  it('keeps returning null after reaching the end', async () => {
+    const dir = open();
+    try {
+      expect(dir.readSync()!.name).toBe('file');
+      expect(dir.readSync()).toBeNull();
+      expect(dir.readSync()).toBeNull();
+      expect(await dir.read()).toBeNull();
+    } finally {
+      dir.closeSync();
+    }
+  });
+  it.each(['complete', 'break', 'throw'])('closes after %s iteration', async mode => {
+    const dir = open();
+    const error = new Error('consumer failed');
+    try {
+      for await (const entry of dir) {
+        expect(entry.name).toBe('file');
+        if (mode === 'break') break;
+        if (mode === 'throw') throw error;
+      }
+    } catch (caught) {
+      expect(mode).toBe('throw');
+      expect(caught).toBe(error);
+    }
+    await expect(dir.read()).rejects.toMatchObject({ code: 'ERR_DIR_CLOSED' });
+  });
+  const itDispose = backend === 'node' && !fs.Dir.prototype[Symbol.asyncDispose] ? it.skip : it;
+  itDispose('can be disposed after automatic iterator cleanup', async () => {
+    const dir = open();
+    for await (const entry of dir) {
+      expect(entry.name).toBe('file');
+    }
+    await expect(dir[Symbol.asyncDispose]()).resolves.toBeUndefined();
+    expect(() => dir[Symbol.dispose]()).not.toThrow();
+  });
+});

--- a/packages/fs-node/src/__tests__/Dir.lifecycle.test.ts
+++ b/packages/fs-node/src/__tests__/Dir.lifecycle.test.ts
@@ -45,7 +45,12 @@ describe.each(['node', 'memfs'])('Dir lifecycle (%s)', backend => {
     }
     await expect(dir.read()).rejects.toMatchObject({ code: 'ERR_DIR_CLOSED' });
   });
-  const itDispose = backend === 'node' && !fs.Dir.prototype[Symbol.asyncDispose] ? it.skip : it;
+  const itDispose =
+    typeof Symbol.asyncDispose === 'undefined' ||
+    typeof Symbol.dispose === 'undefined' ||
+    (backend === 'node' && !fs.Dir.prototype[Symbol.asyncDispose])
+      ? it.skip
+      : it;
   itDispose('can be disposed after automatic iterator cleanup', async () => {
     const dir = open();
     for await (const entry of dir) {

--- a/packages/fs-node/src/__tests__/Dirent.test.ts
+++ b/packages/fs-node/src/__tests__/Dirent.test.ts
@@ -95,12 +95,8 @@ describe('Dirent', () => {
       });
       const dir = vol.opendirSync('/y');
       const parentPaths: string[] = [];
-      try {
-        for await (const dirent of dir) {
-          parentPaths.push((dirent as Dirent).parentPath);
-        }
-      } finally {
-        dir.closeSync();
+      for await (const dirent of dir) {
+        parentPaths.push((dirent as Dirent).parentPath);
       }
       expect(parentPaths).toEqual(['/y', '/y']);
     });


### PR DESCRIPTION
Bring `Dir` end-of-iteration behavior in line with Node.js: repeated reads after EOF keep returning `null`, and async iteration closes the directory on completion, `break`, or an exception in the consumer. Make explicit resource disposal idempotent so it remains safe after automatic iterator cleanup; direct `close()` still reports `ERR_DIR_CLOSED` on a second close.

The same lifecycle regression tests run against native Node.js and memfs. Before the fix all five native cases pass on Node 24 and all five memfs cases fail. One existing Dirent test was updated to rely on the iterator's automatic close instead of closing the directory a second time.

Validation: full `yarn test`, workspace typechecks, and repository Prettier check. Resource-disposal comparisons are skipped when the test environment does not expose the disposal symbols or the native API. Node 22 full suite: 1,446 passed, 20 skipped. Node 24: all 10 lifecycle comparison cases pass; full suite: 1,448 passed, 18 skipped.

AI-assisted implementation and validation.
