### PR TITLE
fix(fs-node): finish BYOB file stream reads at EOF

### DIFF
--- a/packages/fs-node/src/FileHandle.ts
+++ b/packages/fs-node/src/FileHandle.ts
@@ -152,6 +152,7 @@ export class FileHandle extends EventEmitter implements IFileHandle {
 
           if (result.bytesRead === 0) {
             controller.close();
+            controller.byobRequest.respond(0);
             unlockAndCleanup();
             return;
           }

--- a/packages/fs-node/src/__tests__/volume/FileHandle.web-stream.test.ts
+++ b/packages/fs-node/src/__tests__/volume/FileHandle.web-stream.test.ts
@@ -1,0 +1,46 @@
+import * as fs from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { createFs } from '../util';
+
+describe.each(['node', 'memfs'])('FileHandle Web Stream (%s)', backend => {
+  it.each([
+    ['default', ''],
+    ['default', 'hello'],
+    ['byob', ''],
+    ['byob', 'hello'],
+  ])('finishes %s reads for %j', async (mode, content) => {
+    const directory = fs.mkdtempSync(join(tmpdir(), 'memfs-web-stream-'));
+    const path = join(directory, 'file');
+    const api = backend === 'node' ? fs : createFs();
+    if (backend === 'memfs') api.mkdirSync(directory, { recursive: true });
+    api.writeFileSync(path, content);
+    const handle = await api.promises.open(path, 'r');
+    const stream = handle.readableWebStream();
+    const reader = mode === 'byob' ? stream.getReader({ mode: 'byob' }) : stream.getReader();
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    try {
+      const consume = async () => {
+        const chunks: Buffer[] = [];
+        while (true) {
+          const result =
+            mode === 'byob'
+              ? await (reader as ReadableStreamBYOBReader).read(new Uint8Array(3))
+              : await (reader as ReadableStreamDefaultReader<Uint8Array>).read();
+          if (result.done) break;
+          chunks.push(Buffer.from(result.value!));
+        }
+        return Buffer.concat(chunks).toString();
+      };
+      const timeout = new Promise<never>((_, reject) => {
+        timer = setTimeout(() => reject(new Error('stream did not finish at EOF')), 1000);
+      });
+      expect(await Promise.race([consume(), timeout])).toBe(content);
+    } finally {
+      clearTimeout(timer);
+      await reader.cancel().catch(() => {});
+      await handle.close();
+      fs.rmSync(directory, { recursive: true });
+    }
+  });
+});


### PR DESCRIPTION
A BYOB reader of `FileHandle.readableWebStream()` never resolves its final `read()` when the file reaches EOF, including for an empty file. Closing a byte stream does not settle an outstanding BYOB request: respond with zero bytes after closing the controller so the reader receives `done: true`.

The regression suite consumes empty and non-empty files with both default and BYOB readers against native Node.js and memfs. Before the fix both memfs BYOB cases time out; the corresponding native cases and default-reader controls pass.

Validation on Node 24: full `yarn test` passed (1,446 tests, 18 existing skips, 14 snapshots), workspace typechecks and repository Prettier check passed.

AI-assisted implementation and validation.
