### PR TITLE
fix(fs-node): close the original descriptor after stream release

### DIFF
--- a/packages/fs-node/src/FileHandle.ts
+++ b/packages/fs-node/src/FileHandle.ts
@@ -263,9 +263,10 @@ export class FileHandle extends EventEmitter implements IFileHandle {
   private unref(): void {
     this.refs--;
     if (this.refs === 0) {
+      const currentFd = this.fd;
       this.fd = -1;
       if (this.closeResolve) {
-        promisify(this.fs, 'close')(this.fd).then(this.closeResolve, this.closeReject);
+        promisify(this.fs, 'close')(currentFd).then(this.closeResolve, this.closeReject);
       }
     }
   }

--- a/packages/fs-node/src/__tests__/volume/FileHandle.test.ts
+++ b/packages/fs-node/src/__tests__/volume/FileHandle.test.ts
@@ -389,6 +389,23 @@ describe('FileHandle', () => {
   });
 
   describe('reference counting', () => {
+    it.each([false, true])('closes the original descriptor after stream cancellation (read=%s)', async read => {
+      const fs = createFs({ '/test': 'content' });
+      const handle = await fs.promises.open('/test', 'r');
+      const fd = handle.fd;
+      const reader = handle.readableWebStream().getReader();
+      if (read) await reader.read();
+      const closed = handle.close();
+      const closedAgain = handle.close();
+      expect(closedAgain).toBe(closed);
+      expect(fs.fstatSync(fd).isFile()).toBe(true);
+      await reader.cancel();
+      await expect(closed).resolves.toBeUndefined();
+      expect(handle.fd).toBe(-1);
+      expect(() => fs.fstatSync(fd)).toThrow(expect.objectContaining({ code: 'EBADF' }));
+      await expect(handle.close()).resolves.toBeUndefined();
+    });
+
     it('should handle multiple close calls gracefully', async () => {
       const fs = createFs();
       fs.writeFileSync('/test', 'content');


### PR DESCRIPTION
When `FileHandle.close()` waits for an active Web Stream reference, cancelling that stream runs `unref()`. The method sets `fd = -1` before passing the descriptor to `fs.close()`, so the pending close rejects with `EBADF` and the original descriptor remains open. Capture the original descriptor before marking the handle closed, as the immediate close path already does.

Regression tests cover cancellation both before and after a stream read, shared concurrent close calls, and an assertion that the original descriptor is actually closed. Both new cases fail with `EBADF` before the fix.

Validation: full `yarn test`, workspace typechecks, and repository Prettier check passed.

AI-assisted implementation and validation.
